### PR TITLE
remove checkstyle rule NewlineAtEndOfFile

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -4,7 +4,6 @@
     "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 <module name="Checker">
     <module name="SuppressionCommentFilter"/>
-    <module name="NewlineAtEndOfFile"/>
 
     <module name="FileLength"/>
 


### PR DESCRIPTION
If I understand correctly, this rule is mostly meant to deal with very
old source control systems like CVS, and I don't think that any tools we
are working with here care about new lines at the end of the file.
Mostly this just causes annoyances.