### PR TITLE
add 'skip' parameter to maven plugin

### DIFF
--- a/maven-plugin/src/main/java/com/spotify/missinglink/maven/CheckMojo.java
+++ b/maven-plugin/src/main/java/com/spotify/missinglink/maven/CheckMojo.java
@@ -96,6 +96,9 @@ public class CheckMojo extends AbstractMojo {
   @Parameter(defaultValue = "${project}", readonly = true, required = true)
   protected MavenProject project;
 
+  @Parameter(property = "missinglink.skip")
+  protected boolean skip = false;
+
   /**
    * Controls whether the Maven build should be failed if any dependency conflicts are found.
    * Defaults to false.
@@ -179,6 +182,11 @@ public class CheckMojo extends AbstractMojo {
   protected ConflictChecker conflictChecker = new ConflictChecker();
 
   public void execute() throws MojoExecutionException, MojoFailureException {
+
+    if (skip) {
+      getLog().info("skipping plugin execution since missinglink.skip=true");
+      return;
+    }
 
     // when verbose flag is set, log detailed messages to info log. otherwise log to debug. This is
     // so that verbose output from this plugin can be seen easily without having to specify mvn -X.

--- a/maven-plugin/src/test/java/com/spotify/missinglink/maven/CheckMojoTest.java
+++ b/maven-plugin/src/test/java/com/spotify/missinglink/maven/CheckMojoTest.java
@@ -58,6 +58,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -345,5 +346,12 @@ public class CheckMojoTest {
     mojo.execute();
 
     verify(artifactLoader).load(new File(testPath));
+  }
+
+  @Test
+  public void testSkip() throws Exception {
+    getMojo("skip").execute();
+
+    verifyNoMoreInteractions(conflictChecker, artifactLoader);
   }
 }

--- a/maven-plugin/src/test/projects/skip/pom.xml
+++ b/maven-plugin/src/test/projects/skip/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2015 Spotify AB
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.spacesprockets</groupId>
+  <artifactId>foo-bar</artifactId>
+  <version>1.2.3</version>
+  <packaging>jar</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.spotify</groupId>
+        <artifactId>missinglink-maven-plugin</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Similar to `maven.test.skip`, a parameter like this can be useful to
customize execution from the command-line for projects where the plugin
is configured and bound to execute at a certain phase in pom.xml