### PR TITLE
optimizations around memory allocation and footprint

### DIFF
--- a/benchmarks/capture_flight_recording.sh
+++ b/benchmarks/capture_flight_recording.sh
@@ -14,8 +14,9 @@ if [[ ! -e $POM_PATH ]]; then
 fi
 
 PLUGIN=com.spotify:missinglink-maven-plugin:0.1.1-SNAPSHOT
-# use the default "profile" template for flight recorder, the default won't have some stuff enabled
-JFR_SETTINGS=$JAVA_HOME/jre/lib/jfr/profile.jfc
+# use a modified "profile" template for flight recorder, the default won't have some stuff enabled
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+JFR_SETTINGS=$DIR/profile.jfc
 
 # launch maven
 JFR_OPTS="-XX:+UnlockCommercialFeatures -XX:+FlightRecorder -XX:StartFlightRecording=duration=60s,filename=$RECORDING_FILENAME,settings=$JFR_SETTINGS"

--- a/benchmarks/capture_flight_recording.sh
+++ b/benchmarks/capture_flight_recording.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -x
+if [[ $# -lt 2 ]]; then
+    echo "Usage: $0 <filename for recording> <path to pom of project to run missinglink on>"
+    exit 1
+fi
+
+RECORDING_FILENAME=$1
+POM_PATH=$2
+
+if [[ ! -e $POM_PATH ]]; then
+    echo "Error: $POM_PATH does not exist!"
+    exit 2
+fi
+
+PLUGIN=com.spotify:missinglink-maven-plugin:0.1.1-SNAPSHOT
+MAVEN_OPTS="-XX:+UnlockCommercialFeatures -XX:+FlightRecorder -XX:StartFlightRecording=duration=60s,filename=$RECORDING_FILENAME" mvn $PLUGIN:check -f "$POM_PATH"

--- a/benchmarks/capture_flight_recording.sh
+++ b/benchmarks/capture_flight_recording.sh
@@ -14,4 +14,9 @@ if [[ ! -e $POM_PATH ]]; then
 fi
 
 PLUGIN=com.spotify:missinglink-maven-plugin:0.1.1-SNAPSHOT
-MAVEN_OPTS="-XX:+UnlockCommercialFeatures -XX:+FlightRecorder -XX:StartFlightRecording=duration=60s,filename=$RECORDING_FILENAME" mvn $PLUGIN:check -f "$POM_PATH"
+# use the default "profile" template for flight recorder, the default won't have some stuff enabled
+JFR_SETTINGS=$JAVA_HOME/jre/lib/jfr/profile.jfc
+
+# launch maven
+JFR_OPTS="-XX:+UnlockCommercialFeatures -XX:+FlightRecorder -XX:StartFlightRecording=duration=60s,filename=$RECORDING_FILENAME,settings=$JFR_SETTINGS"
+MAVEN_OPTS=$JFR_OPTS mvn $PLUGIN:check -f "$POM_PATH"

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -72,6 +72,15 @@
           </execution>
         </executions>
       </plugin>
+
+      <!-- no need to deploy the benchmarks jar anywhere -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.spotify</groupId>
+    <artifactId>missinglink-parent</artifactId>
+    <version>0.1.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>missinglink-benchmarks</artifactId>
+  <packaging>jar</packaging>
+
+  <properties>
+    <jmh.version>1.9.2</jmh.version>
+    <uberjar.name>benchmarks</uberjar.name>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>missinglink-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>${jmh.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>${jmh.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- shade the jar for JMH -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>${uberjar.name}</finalName>
+              <transformers>
+                <transformer
+                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.openjdk.jmh.Main</mainClass>
+                </transformer>
+              </transformers>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+
+</project>

--- a/benchmarks/profile.jfc
+++ b/benchmarks/profile.jfc
@@ -1,0 +1,427 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration version="1.0" name="Profiling (1)" description="Low overhead configuration for profiling, typically around 2 % overhead." provider="Oracle">
+
+  <producer uri="http://www.oracle.com/hotspot/jvm/" label="Oracle JDK">
+
+    <event path="java/statistics/thread_allocation">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="java/statistics/class_loading">
+      <setting name="enabled">true</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event path="java/statistics/threads">
+      <setting name="enabled">true</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event path="java/thread_start">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="java/thread_end">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="java/thread_sleep">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">10 ms</setting>
+    </event>
+
+    <event path="java/thread_park">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">10 ms</setting>
+    </event>
+
+    <event path="java/monitor_enter">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">10 ms</setting>
+    </event>
+
+    <event path="java/monitor_wait">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">10 ms</setting>
+    </event>
+
+    <event path="vm/class/load">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event path="vm/class/unload">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event path="vm/info">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/initial_system_property">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/prof/execution_sample">
+      <setting name="enabled">true</setting>
+      <setting name="period">10 ms</setting>
+    </event>
+
+    <event path="vm/prof/execution_sampling_info">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">1 ms</setting>
+    </event>
+
+    <event path="vm/runtime/execute_vm_operation">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">10 ms</setting>
+    </event>
+
+    <event path="vm/runtime/thread_dump">
+      <setting name="enabled">true</setting>
+      <setting name="period">60 s</setting>
+    </event>
+
+    <event path="vm/flag/long">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/flag/ulong">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/flag/double">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/flag/boolean">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/flag/string">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/flag/long_changed">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/flag/ulong_changed">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/flag/double_changed">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/flag/boolean_changed">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/flag/string_changed">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/gc/detailed/object_count">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/gc/configuration/gc">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/gc/configuration/heap">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/gc/configuration/young_generation">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/gc/configuration/tlab">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/gc/configuration/survivor">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/gc/detailed/object_count_after_gc">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/gc/heap/summary">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/gc/heap/ps_summary">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/gc/heap/metaspace_summary">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/gc/metaspace/gc_threshold">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/gc/metaspace/allocation_failure">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event path="vm/gc/metaspace/out_of_memory">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event path="vm/gc/metaspace/chunk_free_list_summary">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/gc/collector/garbage_collection">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event path="vm/gc/collector/parold_garbage_collection">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event path="vm/gc/collector/young_garbage_collection">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event path="vm/gc/collector/old_garbage_collection">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event path="vm/gc/collector/g1_garbage_collection">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event path="vm/gc/phases/pause">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event path="vm/gc/phases/pause_level_1">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event path="vm/gc/phases/pause_level_2">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event path="vm/gc/phases/pause_level_3">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event path="vm/gc/reference/statistics">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/gc/detailed/promotion_failed">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/gc/detailed/evacuation_failed">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/gc/detailed/evacuation_info">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/gc/detailed/concurrent_mode_failure">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/compiler/config">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/compiler/stats">
+      <setting name="enabled">true</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event path="vm/compiler/compilation">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">100 ms</setting>
+    </event>
+
+    <event path="vm/compiler/phase">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">10 s</setting>
+    </event>
+
+    <event path="vm/compiler/failure">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/code_sweeper/config">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/code_sweeper/stats">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/code_sweeper/sweep">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">100 ms</setting>
+    </event>
+
+    <event path="vm/code_cache/config">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/code_cache/stats">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/code_cache/full">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="os/information">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="os/processor/cpu_information">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="os/processor/context_switch_rate">
+      <setting name="enabled">true</setting>
+      <setting name="period">10 s</setting>
+    </event>
+
+    <event path="os/processor/cpu_load">
+      <setting name="enabled">true</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event path="os/processor/cpu_tsc">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="os/system_process">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="os/initial_environment_variable">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="os/memory/physical_memory">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="java/object_alloc_in_new_TLAB">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event path="java/object_alloc_outside_TLAB">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+  </producer>
+
+  <producer uri="http://www.oracle.com/hotspot/jdk/" label="Oracle JDK">
+
+    <event path="java/file_read">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">10 ms</setting>
+    </event>
+
+    <event path="java/file_write">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">10 ms</setting>
+    </event>
+
+    <event path="java/socket_read">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">10 ms</setting>
+    </event>
+
+    <event path="java/socket_write">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">10 ms</setting>
+    </event>
+
+    <event path="java/exception_throw">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event path="java/error_throw">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event path="java/statistics/throwables">
+      <setting name="enabled">true</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+  </producer>
+
+  <producer uri="http://www.oracle.com/hotspot/jfr-info/" label="Oracle JDK">
+
+    <event path="recordings/recording">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="recordings/recording_setting">
+      <setting name="enabled">true</setting>
+    </event>
+
+  </producer>
+
+</configuration>

--- a/benchmarks/src/main/java/com/spotify/missinglink/benchmarks/PrimitiveTypeDescriptorBenchmark.java
+++ b/benchmarks/src/main/java/com/spotify/missinglink/benchmarks/PrimitiveTypeDescriptorBenchmark.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2015 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.spotify.missinglink.benchmarks;
+
+import com.spotify.missinglink.datamodel.PrimitiveTypeDescriptor;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+
+@State(Scope.Benchmark)
+public class PrimitiveTypeDescriptorBenchmark {
+
+  /**
+   * This class holds the raw String value to use to pass to
+   * {@link PrimitiveTypeDescriptor#fromRaw(String)}. The annotations used set up JMH to use the
+   * one holder per test thread, and set up a new value for each iteration of the benchmark (not
+   * each invocation).
+   */
+  @State(Scope.Thread)
+  public static class RawStringHolder {
+
+    private String value;
+
+    @Setup(Level.Iteration)
+    public void assignValue() {
+      final int size = PrimitiveTypeDescriptor.values().length;
+      int ix = ThreadLocalRandom.current().nextInt(size);
+      this.value = PrimitiveTypeDescriptor.values()[ix].getRaw();
+    }
+  }
+
+  /** Test the ImmutableMap lookup method in the current source code. */
+  @Benchmark
+  public PrimitiveTypeDescriptor originalMethod(RawStringHolder holder) {
+    return PrimitiveTypeDescriptor.fromRaw(holder.value);
+  }
+
+  // ------------------------------------------------------------------------------------
+  // test using a hashmap instead of ImmutableMap
+
+  private Map<String, PrimitiveTypeDescriptor> hashMap;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    this.hashMap = new HashMap<>();
+    for (PrimitiveTypeDescriptor ptd : PrimitiveTypeDescriptor.values()) {
+      this.hashMap.put(ptd.getRaw(), ptd);
+    }
+  }
+
+  @Benchmark
+  public PrimitiveTypeDescriptor fromHashMap(RawStringHolder holder) {
+    return hashMap.get(holder.value);
+  }
+
+  // ------------------------------------------------------------------------------------
+  // what if we just iterated over all 8 enums each time?
+
+  @Benchmark
+  public PrimitiveTypeDescriptor dumbIteration(RawStringHolder holder) {
+    for (PrimitiveTypeDescriptor ptd : PrimitiveTypeDescriptor.values()) {
+      if (ptd.getRaw().equals(holder.value)) {
+        return ptd;
+      }
+    }
+    return null;
+  }
+}

--- a/core/src/main/java/com/spotify/missinglink/CheckerState.java
+++ b/core/src/main/java/com/spotify/missinglink/CheckerState.java
@@ -16,8 +16,8 @@
 package com.spotify.missinglink;
 
 import com.spotify.missinglink.datamodel.ArtifactName;
+import com.spotify.missinglink.datamodel.ClassTypeDescriptor;
 import com.spotify.missinglink.datamodel.DeclaredClass;
-import com.spotify.missinglink.datamodel.TypeDescriptor;
 
 import java.util.Map;
 import java.util.Optional;
@@ -27,9 +27,9 @@ import io.norberg.automatter.AutoMatter;
 
 @AutoMatter
 interface CheckerState {
-  Map<TypeDescriptor, ArtifactName> sourceMappings();
+  Map<ClassTypeDescriptor, ArtifactName> sourceMappings();
 
-  Optional<Set<TypeDescriptor>> potentialConflictClasses();
+  Optional<Set<ClassTypeDescriptor>> potentialConflictClasses();
 
-  Map<TypeDescriptor, DeclaredClass> knownClasses();
+  Map<ClassTypeDescriptor, DeclaredClass> knownClasses();
 }

--- a/core/src/main/java/com/spotify/missinglink/ClassLoader.java
+++ b/core/src/main/java/com/spotify/missinglink/ClassLoader.java
@@ -69,7 +69,7 @@ public class ClassLoader {
     DeclaredClassBuilder builder = new DeclaredClassBuilder();
 
     final String className = reader.getClassName();
-    builder.className(new ClassTypeDescriptor(className));
+    builder.className(TypeDescriptors.fromClassName(className));
     final ClassNode classNode = new ClassNode();
     reader.accept(classNode, 0);
 
@@ -108,7 +108,7 @@ public class ClassLoader {
 
           } else {
             thisCalls.add(new CalledMethodBuilder()
-                .owner(new ClassTypeDescriptor(minsn.owner))
+                .owner(TypeDescriptors.fromClassName(minsn.owner))
                 .descriptor(MethodDescriptors.fromDesc(minsn.desc, minsn.name))
                 .lineNumber(lineNumber)
                 .build());
@@ -122,7 +122,7 @@ public class ClassLoader {
                 new AccessedFieldBuilder()
                     .name(finsn.name)
                     .descriptor(TypeDescriptors.fromRaw(finsn.desc))
-                    .owner(new ClassTypeDescriptor(finsn.owner))
+                    .owner(TypeDescriptors.fromClassName(finsn.owner))
                     .lineNumber(lineNumber)
                     .build());
           }
@@ -144,11 +144,11 @@ public class ClassLoader {
     final Set<ClassTypeDescriptor> parents = new HashSet<>();
     parents.addAll(ClassLoader.<String>uncheckedCast(classNode.interfaces)
         .stream()
-        .map(ClassTypeDescriptor::new)
+        .map(TypeDescriptors::fromClassName)
         .collect(toList()));
     // java/lang/Object has no superclass
     if (classNode.superName != null) {
-      parents.add(new ClassTypeDescriptor(classNode.superName));
+      parents.add(TypeDescriptors.fromClassName(classNode.superName));
     }
 
     builder.methods(ImmutableMap.copyOf(declaredMethods))

--- a/core/src/main/java/com/spotify/missinglink/ConflictChecker.java
+++ b/core/src/main/java/com/spotify/missinglink/ConflictChecker.java
@@ -243,10 +243,10 @@ public class ConflictChecker {
 
   public static ImmutableSet<TypeDescriptor> reachableFrom(
       ImmutableCollection<DeclaredClass> values,
-      Map<TypeDescriptor, DeclaredClass> knownClasses) {
+      Map<ClassTypeDescriptor, DeclaredClass> knownClasses) {
     Queue<DeclaredClass> toCheck = new LinkedList<>(values);
 
-    Set<TypeDescriptor> reachable = Sets.newHashSet();
+    Set<ClassTypeDescriptor> reachable = Sets.newHashSet();
 
     while (!toCheck.isEmpty()) {
       DeclaredClass current = toCheck.remove();
@@ -322,7 +322,7 @@ public class ConflictChecker {
   }
 
   private boolean missingMethod(MethodDescriptor descriptor, DeclaredClass calledClass,
-                                Map<TypeDescriptor, DeclaredClass> classMap) {
+                                Map<ClassTypeDescriptor, DeclaredClass> classMap) {
     final DeclaredMethod method = calledClass.methods().get(descriptor);
     if (method != null) {
       // TODO: also validate return type
@@ -348,7 +348,7 @@ public class ConflictChecker {
   }
 
   private boolean missingField(DeclaredField field, DeclaredClass calledClass,
-                               Map<TypeDescriptor, DeclaredClass> classMap) {
+                               Map<ClassTypeDescriptor, DeclaredClass> classMap) {
 
     if (calledClass.fields().contains(field)) {
       // TODO: also validate return type

--- a/core/src/main/java/com/spotify/missinglink/datamodel/ClassTypeDescriptor.java
+++ b/core/src/main/java/com/spotify/missinglink/datamodel/ClassTypeDescriptor.java
@@ -23,7 +23,7 @@ public class ClassTypeDescriptor implements TypeDescriptor {
 
   private final String className;
 
-  public ClassTypeDescriptor(String className) {
+  ClassTypeDescriptor(String className) {
     this.className = Preconditions.checkNotNull(className).replace('/', '.');
     if (className.endsWith(";")) {
       throw new InputMismatchException(

--- a/core/src/main/java/com/spotify/missinglink/datamodel/MethodDescriptors.java
+++ b/core/src/main/java/com/spotify/missinglink/datamodel/MethodDescriptors.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 
 import org.objectweb.asm.Type;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static java.util.stream.Collectors.toList;
@@ -31,7 +32,7 @@ public final class MethodDescriptors {
   public static MethodDescriptor fromDesc(String desc, String name) {
     Type type = Type.getMethodType(desc);
 
-    List<TypeDescriptor> params = ImmutableList.copyOf(type.getArgumentTypes()).stream()
+    List<TypeDescriptor> params = Arrays.stream(type.getArgumentTypes())
         .map(Type::getDescriptor)
         .map(TypeDescriptors::fromRaw)
         .collect(toList());

--- a/core/src/main/java/com/spotify/missinglink/datamodel/MethodDescriptors.java
+++ b/core/src/main/java/com/spotify/missinglink/datamodel/MethodDescriptors.java
@@ -15,12 +15,15 @@
  */
 package com.spotify.missinglink.datamodel;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import org.objectweb.asm.Type;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static java.util.stream.Collectors.toList;
 
@@ -30,7 +33,12 @@ public final class MethodDescriptors {
   }
 
   public static MethodDescriptor fromDesc(String desc, String name) {
-    Type type = Type.getMethodType(desc);
+    final MethodKey key = new MethodKey(name, desc);
+    return methodDescriptorCache.computeIfAbsent(key, MethodDescriptors::newDescriptor);
+  }
+
+  private static MethodDescriptor newDescriptor(MethodKey key) {
+    Type type = Type.getMethodType(key.desc);
 
     List<TypeDescriptor> params = Arrays.stream(type.getArgumentTypes())
         .map(Type::getDescriptor)
@@ -39,8 +47,45 @@ public final class MethodDescriptors {
 
     return new MethodDescriptorBuilder()
         .returnType(TypeDescriptors.fromRaw(type.getReturnType().getDescriptor()))
-        .name(name)
+        .name(key.name)
         .parameterTypes(ImmutableList.copyOf(params))
         .build();
+  }
+
+  private static final Map<MethodKey, MethodDescriptor> methodDescriptorCache = new HashMap<>();
+
+  private static class MethodKey {
+    private final String name;
+    private final String desc;
+
+    public MethodKey(String name, String desc) {
+      this.name = Preconditions.checkNotNull(name);
+      this.desc = Preconditions.checkNotNull(desc);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      MethodKey key = (MethodKey) o;
+
+      if (!name.equals(key.name)) {
+        return false;
+      }
+      return desc.equals(key.desc);
+
+    }
+
+    @Override
+    public int hashCode() {
+      int result = name.hashCode();
+      result = 31 * result + desc.hashCode();
+      return result;
+    }
   }
 }

--- a/core/src/main/java/com/spotify/missinglink/datamodel/PrimitiveTypeDescriptor.java
+++ b/core/src/main/java/com/spotify/missinglink/datamodel/PrimitiveTypeDescriptor.java
@@ -25,7 +25,7 @@ public enum PrimitiveTypeDescriptor implements TypeDescriptor {
   private final char raw;
   private final String pretty;
 
-  private PrimitiveTypeDescriptor(char raw, String pretty) {
+  PrimitiveTypeDescriptor(char raw, String pretty) {
     this.raw = raw;
     this.pretty = pretty;
   }
@@ -35,6 +35,9 @@ public enum PrimitiveTypeDescriptor implements TypeDescriptor {
     return pretty;
   }
 
+  public String getRaw() {
+    return Character.toString(raw);
+  }
 
   private static final ImmutableMap<String, PrimitiveTypeDescriptor> mapping = createMapping();
 

--- a/core/src/main/java/com/spotify/missinglink/datamodel/TypeDescriptors.java
+++ b/core/src/main/java/com/spotify/missinglink/datamodel/TypeDescriptors.java
@@ -15,14 +15,24 @@
  */
 package com.spotify.missinglink.datamodel;
 
+import java.util.HashMap;
 import java.util.InputMismatchException;
+import java.util.Map;
 
 public class TypeDescriptors {
+
   private TypeDescriptors() {
   }
 
-  public static TypeDescriptor fromClassName(String className) {
-    return new ClassTypeDescriptor(className);
+  // Keep a cache of all the created ClassTypeDescriptor instances to prevent unnecessary
+  // duplication of instances. ClassTypeDescriptor is immutable once constructed.
+  // Since the CTD constructor involves string replacement, and there are several places where we
+  // want to turn a String into a ClassTypeDescriptor, we can optimize how many strings are
+  // created/replaced with this map.
+  private static Map<String, ClassTypeDescriptor> classTypeDescriptorCache = new HashMap<>();
+
+  public static ClassTypeDescriptor fromClassName(String className) {
+    return classTypeDescriptorCache.computeIfAbsent(className, ClassTypeDescriptor::new);
   }
 
   public static TypeDescriptor fromRaw(String raw) {

--- a/core/src/test/java/com/spotify/missinglink/ArtifactLoaderTest.java
+++ b/core/src/test/java/com/spotify/missinglink/ArtifactLoaderTest.java
@@ -115,21 +115,21 @@ public class ArtifactLoaderTest {
   @Test
   public void testLoadClass() throws Exception {
     assertNotNull("Artifact must contain class 'A'",
-        artifact.classes().get(new ClassTypeDescriptor("A")));
+        artifact.classes().get(TypeDescriptors.fromClassName("A")));
   }
 
   @Test
   public void testLoadMethod() throws Exception {
     assertTrue("Class must contain method with hairy signature", artifact.classes().get(
-        new ClassTypeDescriptor("A")).methods().containsKey(methodOneDescriptor));
+        TypeDescriptors.fromClassName("A")).methods().containsKey(methodOneDescriptor));
   }
 
   @Test
   public void testLoadCall() throws Exception {
-    DeclaredMethod method =
-        artifact.classes().get(new ClassTypeDescriptor("A")).methods().get(methodOneDescriptor);
+    final DeclaredClass declaredClass = artifact.classes().get(TypeDescriptors.fromClassName("A"));
+    DeclaredMethod method = declaredClass.methods().get(methodOneDescriptor);
     CalledMethod call = new CalledMethodBuilder()
-        .owner(new ClassTypeDescriptor("java/io/PrintStream"))
+        .owner(TypeDescriptors.fromClassName("java/io/PrintStream"))
         .lineNumber(15)
         .descriptor(printlnDescriptor).build();
     assertTrue("Method must contain call to other method with hairy signature",
@@ -138,7 +138,7 @@ public class ArtifactLoaderTest {
 
   @Test
   public void testLoadField() throws Exception {
-    DeclaredClass loadedClass = artifact.classes().get(new ClassTypeDescriptor("A"));
+    DeclaredClass loadedClass = artifact.classes().get(TypeDescriptors.fromClassName("A"));
     DeclaredField myField = new DeclaredFieldBuilder().name("publicFieldOne")
         .descriptor(TypeDescriptors.fromRaw("Ljava/lang/Object;")).build();
     assertTrue("Class must contain field with hairy signature",
@@ -147,7 +147,7 @@ public class ArtifactLoaderTest {
 
   @Test
   public void testLoadStaticFieldAccess() throws Exception {
-    DeclaredMethod method = artifact.classes().get(new ClassTypeDescriptor("A")).methods()
+    DeclaredMethod method = artifact.classes().get(TypeDescriptors.fromClassName("A")).methods()
         .get(internalStaticFieldAccessDescriptor);
     AccessedField access = Simple.newAccess("Ljava/lang/Object;", "staticFieldOne", "A", 11);
     assertTrue("Method must contain access to staticFieldOne: " + method.fieldAccesses()
@@ -156,7 +156,7 @@ public class ArtifactLoaderTest {
 
   @Test
   public void testLoadFieldAccess() throws Exception {
-    DeclaredMethod method = artifact.classes().get(new ClassTypeDescriptor("A")).methods()
+    DeclaredMethod method = artifact.classes().get(TypeDescriptors.fromClassName("A")).methods()
         .get(internalFieldAccessDescriptor);
     AccessedField access = Simple.newAccess("Ljava/lang/Object;", "publicFieldOne", "A", 12);
     assertTrue("Method must contain access to staticFieldOne: " + method.fieldAccesses()
@@ -165,9 +165,8 @@ public class ArtifactLoaderTest {
 
   @Test
   public void testLoadParent() throws Exception {
-    assertEquals(artifact.classes().get(new ClassTypeDescriptor("A")).parents(), ImmutableSet
-        .of(new ClassTypeDescriptor(
-            "java/lang/Object")));
+    assertEquals(artifact.classes().get(TypeDescriptors.fromClassName("A")).parents(), ImmutableSet
+        .of(TypeDescriptors.fromClassName("java/lang/Object")));
   }
 
   /**
@@ -225,7 +224,7 @@ public class ArtifactLoaderTest {
         .overridingErrorMessage("Loading classes from a directory should be supported")
         .isNotEmpty()
             // test that a class known to be in this directory exists in the map
-        .containsKey(new ClassTypeDescriptor(MethodDescriptor.class.getName()));
+        .containsKey(TypeDescriptors.fromClassName(MethodDescriptor.class.getName()));
   }
 
   @Test
@@ -250,12 +249,11 @@ public class ArtifactLoaderTest {
         .orElseThrow(() -> new RuntimeException("call to NestedClass.bar missing?"));
 
     //make sure that the classMap contains an entry for the nestedClassName
-    assertThat(artifact.classes()).containsKey(new ClassTypeDescriptor(nestedClassName));
+    assertThat(artifact.classes()).containsKey(TypeDescriptors.fromClassName(nestedClassName));
   }
 
   private DeclaredClass getDeclaredClass(Artifact artifact, String className) {
-    final ClassTypeDescriptor key = new ClassTypeDescriptor(
-        className);
+    final ClassTypeDescriptor key = TypeDescriptors.fromClassName(className);
     assertThat(artifact.classes()).containsKey(key);
 
     return artifact.classes().get(key);

--- a/core/src/test/java/com/spotify/missinglink/ConflictCheckerTest.java
+++ b/core/src/test/java/com/spotify/missinglink/ConflictCheckerTest.java
@@ -29,6 +29,7 @@ import com.spotify.missinglink.datamodel.DeclaredField;
 import com.spotify.missinglink.datamodel.DeclaredMethodBuilder;
 import com.spotify.missinglink.datamodel.MethodDescriptor;
 import com.spotify.missinglink.datamodel.MethodDescriptorBuilder;
+import com.spotify.missinglink.datamodel.TypeDescriptors;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -47,14 +48,14 @@ public class ConflictCheckerTest {
     cloneDescriptor = new MethodDescriptorBuilder()
         .name("clone")
         .parameterTypes(ImmutableList.of())
-        .returnType(new ClassTypeDescriptor("java/lang/Object"))
+        .returnType(TypeDescriptors.fromClassName("java/lang/Object"))
         .build();
 
     rt = new ArtifactBuilder()
         .name(new ArtifactName("rt"))
         .classes(ImmutableMap.of(
-            new ClassTypeDescriptor("java/lang/Object"), new DeclaredClassBuilder()
-                .className(new ClassTypeDescriptor("java/lang/Object"))
+            TypeDescriptors.fromClassName("java/lang/Object"), new DeclaredClassBuilder()
+                .className(TypeDescriptors.fromClassName("java/lang/Object"))
                 .parents(ImmutableSet.of())
                 .fields(ImmutableSet.<DeclaredField>of())
                 .methods(ImmutableMap.of(
@@ -71,24 +72,24 @@ public class ConflictCheckerTest {
     projectArtifact = new ArtifactBuilder()
         .name(new ArtifactName("foo"))
         .classes(ImmutableMap.of(
-            new ClassTypeDescriptor("com/spotify/ClassName"),
+            TypeDescriptors.fromClassName("com/spotify/ClassName"),
               Simple.newClass("com/spotify/ClassName")
-                .parents(ImmutableSet.of(new ClassTypeDescriptor("java/lang/Object")))
+                .parents(ImmutableSet.of(TypeDescriptors.fromClassName("java/lang/Object")))
                 .methods(Simple.methodMap(
                    Simple.newMethod(Simple.OBJECT, "something")
                        .methodCalls(ImmutableSet.of(new CalledMethodBuilder()
-                           .owner(new ClassTypeDescriptor("java/lang/Object"))
+                           .owner(TypeDescriptors.fromClassName("java/lang/Object"))
                            .descriptor(cloneDescriptor)
                            .build()))
                        .build()))
                 .build()))
         .build();
 
-    ClassTypeDescriptor libClass1 = new ClassTypeDescriptor("org/library/ClassName");
+    ClassTypeDescriptor libClass1 = TypeDescriptors.fromClassName("org/library/ClassName");
     MethodDescriptor brokenMethodDescriptor = new MethodDescriptorBuilder()
         .name("broken")
         .parameterTypes(ImmutableList.of())
-        .returnType(new ClassTypeDescriptor("java/lang/Object"))
+        .returnType(TypeDescriptors.fromClassName("java/lang/Object"))
         .build();
 
     libraryArtifact = new ArtifactBuilder()
@@ -96,12 +97,12 @@ public class ConflictCheckerTest {
         .classes(ImmutableMap.of(
             libClass1, new DeclaredClassBuilder()
                 .className(libClass1)
-                .parents(ImmutableSet.of(new ClassTypeDescriptor("java/lang/Object")))
+                .parents(ImmutableSet.of(TypeDescriptors.fromClassName("java/lang/Object")))
                 .fields(ImmutableSet.<DeclaredField>of())
                 .methods(Simple.methodMap(
                     Simple.newMethod(Simple.OBJECT, "broken")
                         .methodCalls(ImmutableSet.of(new CalledMethodBuilder()
-                            .owner(new ClassTypeDescriptor("java/lang/Object"))
+                            .owner(TypeDescriptors.fromClassName("java/lang/Object"))
                             .descriptor(brokenMethodDescriptor)
                             .build()))
                         .build()))

--- a/core/src/test/java/com/spotify/missinglink/ReachableTest.java
+++ b/core/src/test/java/com/spotify/missinglink/ReachableTest.java
@@ -45,7 +45,8 @@ public class ReachableTest {
   public void testUnreachable() {
     DeclaredClass root = newClass("my/Root").build();
     ImmutableSet< DeclaredClass > myClasses = ImmutableSet.of(root);
-    Map<TypeDescriptor, DeclaredClass> world = classMap(root, newClass("other/Unknown").build());
+    Map<ClassTypeDescriptor, DeclaredClass> world =
+        classMap(root, newClass("other/Unknown").build());
     Set<TypeDescriptor> reachable = ConflictChecker.reachableFrom(myClasses, world);
     assertEquals(ImmutableSet.of(root.className()), reachable);
   }
@@ -63,7 +64,7 @@ public class ReachableTest {
                     ImmutableSet.of(newCall(remote, remoteMethod))).build()))
         .build();
     ImmutableSet<DeclaredClass> myClasses = ImmutableSet.of(root);
-    ImmutableMap<TypeDescriptor, DeclaredClass> world = classMap(root, remote);
+    ImmutableMap<ClassTypeDescriptor, DeclaredClass> world = classMap(root, remote);
     ImmutableSet<TypeDescriptor> reachable = ConflictChecker.reachableFrom(myClasses, world);
     assertEquals(ImmutableSet.of(root.className(), remote.className()), reachable);
   }
@@ -76,7 +77,7 @@ public class ReachableTest {
         .parents(ImmutableSet.of(new ClassTypeDescriptor("other/Unknown")))
         .build();
     ImmutableSet<DeclaredClass> myClasses = ImmutableSet.of(root);
-    ImmutableMap<TypeDescriptor, DeclaredClass> world = classMap(root, remote);
+    ImmutableMap<ClassTypeDescriptor, DeclaredClass> world = classMap(root, remote);
     ImmutableSet<TypeDescriptor> reachable = ConflictChecker.reachableFrom(myClasses, world);
     assertEquals(ImmutableSet.of(root.className(), remote.className()), reachable);
   }
@@ -95,7 +96,7 @@ public class ReachableTest {
         .methods(methods)
         .build();
     ImmutableSet< DeclaredClass > myClasses = ImmutableSet.of(root);
-    ImmutableMap<TypeDescriptor, DeclaredClass> world = classMap(root, remote);
+    ImmutableMap<ClassTypeDescriptor, DeclaredClass> world = classMap(root, remote);
     ImmutableSet<TypeDescriptor> reachable = ConflictChecker.reachableFrom(myClasses, world);
     assertEquals(ImmutableSet.of(root.className(), remote.className()), reachable);
   }

--- a/core/src/test/java/com/spotify/missinglink/ReachableTest.java
+++ b/core/src/test/java/com/spotify/missinglink/ReachableTest.java
@@ -23,6 +23,7 @@ import com.spotify.missinglink.datamodel.DeclaredClass;
 import com.spotify.missinglink.datamodel.DeclaredMethod;
 import com.spotify.missinglink.datamodel.MethodDescriptor;
 import com.spotify.missinglink.datamodel.TypeDescriptor;
+import com.spotify.missinglink.datamodel.TypeDescriptors;
 
 import org.junit.Test;
 
@@ -74,7 +75,7 @@ public class ReachableTest {
     DeclaredClass remote = newClass("other/Unknown")
         .build();
     DeclaredClass root = newClass("my/Root")
-        .parents(ImmutableSet.of(new ClassTypeDescriptor("other/Unknown")))
+        .parents(ImmutableSet.of(TypeDescriptors.fromClassName("other/Unknown")))
         .build();
     ImmutableSet<DeclaredClass> myClasses = ImmutableSet.of(root);
     ImmutableMap<ClassTypeDescriptor, DeclaredClass> world = classMap(root, remote);

--- a/core/src/test/java/com/spotify/missinglink/Simple.java
+++ b/core/src/test/java/com/spotify/missinglink/Simple.java
@@ -92,8 +92,9 @@ public class Simple {
         .build();
   }
 
-  public static ImmutableMap<TypeDescriptor, DeclaredClass> classMap(DeclaredClass... classes) {
-    ImmutableMap.Builder<TypeDescriptor, DeclaredClass> builder = ImmutableMap.builder();
+  public static ImmutableMap<ClassTypeDescriptor, DeclaredClass> classMap(
+      DeclaredClass... classes) {
+    ImmutableMap.Builder<ClassTypeDescriptor, DeclaredClass> builder = ImmutableMap.builder();
     for (DeclaredClass clazz : classes) {
       builder.put(clazz.className(), clazz);
     }

--- a/core/src/test/java/com/spotify/missinglink/Simple.java
+++ b/core/src/test/java/com/spotify/missinglink/Simple.java
@@ -63,7 +63,7 @@ public class Simple {
    */
   public static DeclaredClassBuilder newClass(String className) {
     return new DeclaredClassBuilder()
-        .className(new ClassTypeDescriptor(className))
+        .className(TypeDescriptors.fromClassName(className))
         .parents(ImmutableSet.of())
         .methods(ImmutableMap.of())
         .fields(ImmutableSet.<DeclaredField>of());
@@ -121,7 +121,7 @@ public class Simple {
     return new AccessedFieldBuilder()
         .name(name)
         .descriptor(TypeDescriptors.fromRaw(desc))
-        .owner(new ClassTypeDescriptor(owner))
+        .owner(TypeDescriptors.fromClassName(owner))
         .lineNumber(lineNumber)
         .build();
   }
@@ -137,6 +137,5 @@ public class Simple {
         .classes(builder.build())
         .build();
   }
-
 
 }

--- a/core/src/test/java/com/spotify/missinglink/TypeDescriptorTest.java
+++ b/core/src/test/java/com/spotify/missinglink/TypeDescriptorTest.java
@@ -111,7 +111,7 @@ public class TypeDescriptorTest {
 
   @Test(expected = InputMismatchException.class)
   public void testMoastInvalid() {
-    new ClassTypeDescriptor("LFoo;");
+    TypeDescriptors.fromClassName("LFoo;");
   }
 
   @Test(expected = InputMismatchException.class)
@@ -128,6 +128,8 @@ public class TypeDescriptorTest {
 
   @Test
   public void testNewClassTypeDescriptor() throws Exception {
-    assertEquals(new ClassTypeDescriptor("foo.Bar"), TypeDescriptors.fromClassName("foo/Bar"));
+    final ClassTypeDescriptor a = TypeDescriptors.fromClassName("foo.Bar");
+    final ClassTypeDescriptor b = TypeDescriptors.fromClassName("foo/Bar");
+    assertEquals(a, b);
   }
 }

--- a/maven-plugin/src/test/java/com/spotify/missinglink/maven/CheckMojoTest.java
+++ b/maven-plugin/src/test/java/com/spotify/missinglink/maven/CheckMojoTest.java
@@ -151,7 +151,7 @@ public class CheckMojoTest {
 
   private ImmutableList<Conflict> mockConflicts(ConflictCategory category,
                                                 ConflictCategory... additionalCategories) {
-    final ClassTypeDescriptor ctd = new ClassTypeDescriptor("com/foo/Whatever");
+    final ClassTypeDescriptor ctd = TypeDescriptors.fromClassName("com/foo/Whatever");
     return mockConflicts(ctd, category, additionalCategories);
 
   }
@@ -161,7 +161,7 @@ public class CheckMojoTest {
                                                 ConflictCategory... additionalCategories) {
 
     final CalledMethod callee = new CalledMethodBuilder()
-        .owner(new ClassTypeDescriptor("com/foo/Bar"))
+        .owner(TypeDescriptors.fromClassName("com/foo/Bar"))
         .descriptor(new MethodDescriptorBuilder()
             .returnType(TypeDescriptors.fromRaw("Ljava/lang/String;"))
             .name("bat")
@@ -289,7 +289,7 @@ public class CheckMojoTest {
         );
 
     setMockConflictResults(
-        mockConflicts(new ClassTypeDescriptor("groovy.lang.foo.Bar"),
+        mockConflicts(TypeDescriptors.fromClassName("groovy.lang.foo.Bar"),
             ConflictCategory.CLASS_NOT_FOUND)
     );
 
@@ -299,7 +299,7 @@ public class CheckMojoTest {
   @Test
   public void testIgnoreDestinationPackages() throws Exception {
     final CalledMethod callee = new CalledMethodBuilder()
-        .owner(new ClassTypeDescriptor("com/foo/Bar"))
+        .owner(TypeDescriptors.fromClassName("com/foo/Bar"))
         .descriptor(new MethodDescriptorBuilder()
             .returnType(TypeDescriptors.fromRaw("Ljava/lang/String;"))
             .name("bat")
@@ -319,7 +319,7 @@ public class CheckMojoTest {
 
     // a conflict from com/Whatever => com/foo/Bar.bat where the latter class cannot be found
     setMockConflictResults(ImmutableList.of(
-        conflict(ConflictCategory.CLASS_NOT_FOUND, new ClassTypeDescriptor("com/Whatever"),
+        conflict(ConflictCategory.CLASS_NOT_FOUND, TypeDescriptors.fromClassName("com/Whatever"),
             caller, callee, "class com/foo/Bar not found")
     ));
 

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,11 @@
             <useIncrementalCompilation>false</useIncrementalCompilation>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
   </developers>
 
   <modules>
+    <module>benchmarks</module>
     <module>core</module>
     <module>maven-plugin</module>
   </modules>
@@ -85,6 +86,10 @@
       <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
   </distributionManagement>
+
+  <prerequisites>
+    <maven>3.0</maven>
+  </prerequisites>
 
   <build>
     <pluginManagement>


### PR DESCRIPTION
I ran missinglink through Java Flight Recorder to get profiling info about how many objects are being created during the analysis to see what improvements could be made. 

The test project I ran missinglink against while profiling has a dependency graph of about 51k classes. JFR showed that missinglink is creating millions of ClassTypeDescriptor instances and hundreds of thousands MethodDescriptors when analyzing this project.

Most of the memory allocation pressure is coming from `char[]` and `String` instances, which makes some sense since asm is returning type and method info as Strings and missinglink parses these into objects to work with. 

A snapshot of JFR from the initial state showing that `char[]` is nearly half of the allocation pressure:

![image](https://cloud.githubusercontent.com/assets/113840/8261778/33e13ac2-169b-11e5-803a-b6e07f6597f3.png)

By caching the ClassTypeDescriptor instances (which is safe as they are immutable), we can shave off some of the `String` and `char[]` instances (about 0.5gb for `char[]`) - a lot of the String instances being created were from calls to `String.replace(char, char)` in ClassTypeDescriptor's constructor:

![image](https://cloud.githubusercontent.com/assets/113840/8261809/7abb3a10-169b-11e5-8131-9772e3b36986.png)

By caching the MethodDescriptor instances, the pressure is cut down even more significantly:

![image](https://cloud.githubusercontent.com/assets/113840/8261842/a81dd756-169b-11e5-8c07-b699aed14896.png)

this larger improvement is a result avoiding some of the work done in [MethodDescriptor](https://github.com/spotify/missinglink/blob/5412d55d275a714ca49f936000dcb00c0f3e99a7/core/src/main/java/com/spotify/missinglink/datamodel/MethodDescriptors.java#L32) that calls the asm methods `Type.getMethodType(desc)`, `Type.getDescriptor()` etc. These methods do a lot of string parsing themselves, constructing Types from char arrays and then creating StringBuffers from a Type.

In the initial state, the Java Flight Recording reports `Memory Allocated for TLABs: 5.51 GB` during one run of the maven plugin with a total GC pause time of `20 s 957 ms`.

With the caching changes (at 0c0243e), JFR reports that `Memory Allocated for TLABs: 2.56 GB` and a total GC pause time of `6 s 912 ms`.

So the results of these two changes is that allocation pressure is down by roughly half and the GC time by 2/3rds.

This PR also includes some initial setup work for a general "benchmarks" module using JMH for microbenchmarks. For the improvements in caching ClassTypeDescriptor and MethodDescriptor this module and JMH ended up not being needed, but it seems like it may be useful to have this setup in the future.

The `capture_flight_recording.sh` script was used to ease creating the JFRs, my workflow here was to run `./install_maven_plugin.sh` with my changes and then profile them with:

```sh
./benchmarks/capture_flight_recording.sh ~/Desktop/test-0c0243e.jfr ~/code/the-test-project/
```


