### PR TITLE
fix coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,10 @@ jdk:
   - oraclejdk8
 
 after_success:
-  - mvn clean cobertura:cobertura coveralls:report -Dcoveralls.token=${COVERALLS_TOKEN}
+  # Generate test coverage data with Cobertura and send the results to Coveralls.
+  # Only build the core and maven-plugin modules in this step - coverage for
+  # the benchmarks module is irrelevant.
+  - mvn -am -pl core,maven-plugin clean cobertura:cobertura coveralls:report -Dcoveralls.token=${COVERALLS_TOKEN}
 
 sudo: false
 

--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,9 @@
           <instrumentation>
             <excludes>
               <exclude>com/spotify/missinglink/**/*Builder*.class</exclude>
+              <!-- JMH benchmarks -->
+              <exclude>com/spotify/missinglink/benchmarks/**/*</exclude>
+              <exclude>org/openjdk/jmh/**/*</exclude>
             </excludes>
           </instrumentation>
         </configuration>


### PR DESCRIPTION
Looks like I broke the coveralls integration back when adding the `benchmarks`
module - the coveralls-maven-plugin errors out because it cannot find the
source for classes generated by JMH. Since coverage for "benchmarks" is
irrelevant anyway, exclude the module from Cobertura and Coveralls.

The docs for Coveralls claim that to exclude files you just need to configure
Cobertura (or the coverage library), but it seems like that is not fully
correct for multimodule projects - so I've "excluded" the benchmarks module
from Coveralls by adding the `-pl core,maven-plugin` argument to `.travis.yml`.