### PR TITLE
add warning if no classes found in build directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 0.1.2
+- if no classes found in build directory, log a suggestion to run `mvn compile`
+  first.
+- internal refactoring: add integration tests to Maven build via
+  maven-invoker-plugin (thanks @dflemstr)
+
 ### 0.1.1
 - rename goal in maven-plugin from `check-conflicts` to `check`
 - performance improvements - missinglink allocates less objects during

--- a/maven-plugin/src/main/java/com/spotify/missinglink/maven/CheckMojo.java
+++ b/maven-plugin/src/main/java/com/spotify/missinglink/maven/CheckMojo.java
@@ -487,6 +487,11 @@ public class CheckMojo extends AbstractMojo {
 
     final Artifact projectArtifact = toArtifact(project.getBuild().getOutputDirectory());
 
+    if (projectArtifact.classes().isEmpty()) {
+      getLog().warn("No classes found in project build directory"
+                    + " - did you run 'mvn compile' first?");
+    }
+
     stopwatch.reset().start();
 
     final Collection<Conflict> conflicts = conflictChecker.check(


### PR DESCRIPTION
This is to help suggest to users that they need to run the compiler
before missinglink.

An alternative would be to force the plugin to run in a forked build so
that we can specify that it runs after the `compile` phase, but this
adds time to the user's build and can cause confusion when some plugins
are run twice (once in the regular build and once in the fork).

Resolves #31