### PR TITLE
improve ClassLoader readability

### DIFF
--- a/core/src/main/java/com/spotify/missinglink/ArtifactLoader.java
+++ b/core/src/main/java/com/spotify/missinglink/ArtifactLoader.java
@@ -65,7 +65,7 @@ public class ArtifactLoader {
         JarEntry entry = entries.nextElement();
         if (entry.getName().endsWith(".class")) {
           try {
-            DeclaredClass cl = new ClassLoader(jarFile.getInputStream(entry)).load();
+            DeclaredClass cl = ClassLoader.load(jarFile.getInputStream(entry));
             classes.put(cl.className(), cl);
           } catch (Exception e) {
             System.err.println("Could not load " + entry.getName() + " from " + path);
@@ -84,7 +84,7 @@ public class ArtifactLoader {
 
       for (File file : classFilesInDir) {
         try (FileInputStream fis = new FileInputStream(file)) {
-          DeclaredClass cl = new ClassLoader(fis).load();
+          DeclaredClass cl = ClassLoader.load(fis);
           classes.put(cl.className(), cl);
         }
       }

--- a/core/src/test/java/com/spotify/missinglink/ClassLoaderTest.java
+++ b/core/src/test/java/com/spotify/missinglink/ClassLoaderTest.java
@@ -30,7 +30,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ClassLoaderTest {
 
-  private ClassLoader loader;
   private FileInputStream inputStream;
 
   @Before
@@ -43,7 +42,6 @@ public class ClassLoaderTest {
         .orElseThrow(() -> new IllegalStateException("no classfiles in " + outputDir + " ?"));
 
     inputStream = new FileInputStream(someClass);
-    loader = new ClassLoader(inputStream);
   }
 
   @After
@@ -54,7 +52,7 @@ public class ClassLoaderTest {
   /** Simple test that load() doesn't blow up */
   @Test
   public void testLoad() throws Exception {
-    final DeclaredClass declaredClass = loader.load();
+    final DeclaredClass declaredClass = ClassLoader.load(inputStream);
     assertThat(declaredClass).isNotNull();
     assertThat(declaredClass.methods()).isNotEmpty();
   }

--- a/maven-plugin/src/main/java/com/spotify/missinglink/maven/CheckMojo.java
+++ b/maven-plugin/src/main/java/com/spotify/missinglink/maven/CheckMojo.java
@@ -466,7 +466,7 @@ public class CheckMojo extends AbstractMojo {
 
   private DeclaredClass loadClass(File f) {
     try {
-      return new com.spotify.missinglink.ClassLoader(new FileInputStream(f)).load();
+      return com.spotify.missinglink.ClassLoader.load(new FileInputStream(f));
     } catch (IOException e) {
       throw Throwables.propagate(e);
     }


### PR DESCRIPTION
- change load() to be a static method, to more clearly reflect its nature
- extract different steps in load() to separate, smaller methods for better readability