### PR TITLE
Fix broken link to configuration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Add the following plugin to pom.xml:
 </plugin>
 ```
 
-See [how to configure the plugin below](#Configuration of the plugin).
+See [how to configure the plugin below](#configuration-of-the-plugin).
+
 
 ## Problem definition
 


### PR DESCRIPTION
Super quick fix for a broken markdown link in the README, probably more trouble than it's worth.
Based on https://gist.github.com/asabaylus/3071099

Thanks for this and the article at https://labs.spotify.com/2015/09/01/java-linking/ 🍻 