### PR TITLE
remove Guava from missinglink-core

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.spotify</groupId>
     <artifactId>missinglink-parent</artifactId>
-    <version>0.1.6-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>missinglink-benchmarks</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,9 +24,8 @@
     </dependency>
     <dependency>
       <groupId>io.norberg</groupId>
-      <artifactId>auto-matter</artifactId>
-      <version>0.11.0</version>
-      <scope>provided</scope>
+      <artifactId>auto-matter-annotation</artifactId>
+      <version>0.15.3</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -46,5 +45,24 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>io.norberg</groupId>
+              <artifactId>auto-matter</artifactId>
+              <version>0.15.3</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.spotify</groupId>
     <artifactId>missinglink-parent</artifactId>
-    <version>0.1.6-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>missinglink-core</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -28,11 +28,6 @@
       <version>0.15.3</version>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>18.0</version>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/core/src/main/java/com/spotify/missinglink/datamodel/ArrayTypeDescriptor.java
+++ b/core/src/main/java/com/spotify/missinglink/datamodel/ArrayTypeDescriptor.java
@@ -16,7 +16,7 @@
 package com.spotify.missinglink.datamodel;
 
 
-import com.google.common.base.Preconditions;
+import java.util.Objects;
 
 public class ArrayTypeDescriptor implements TypeDescriptor {
 
@@ -25,7 +25,7 @@ public class ArrayTypeDescriptor implements TypeDescriptor {
 
   public ArrayTypeDescriptor(TypeDescriptor subType, int dimensions) {
     this.dimensions = dimensions;
-    this.subType = Preconditions.checkNotNull(subType);
+    this.subType = Objects.requireNonNull(subType);
   }
 
   @Override

--- a/core/src/main/java/com/spotify/missinglink/datamodel/Artifact.java
+++ b/core/src/main/java/com/spotify/missinglink/datamodel/Artifact.java
@@ -15,9 +15,8 @@
  */
 package com.spotify.missinglink.datamodel;
 
-import com.google.common.collect.ImmutableMap;
-
 import io.norberg.automatter.AutoMatter;
+import java.util.Map;
 
 @AutoMatter
 public interface Artifact {
@@ -26,7 +25,7 @@ public interface Artifact {
   ArtifactName name();
 
   /**
-   * Map of classname to class object. Names are com/foo/bar/Baz
+   * Map of classname to class object. Names are com/foo/bar/Baz. Returned map is immutable.
    */
-  ImmutableMap<ClassTypeDescriptor, DeclaredClass> classes();
+  Map<ClassTypeDescriptor, DeclaredClass> classes();
 }

--- a/core/src/main/java/com/spotify/missinglink/datamodel/ClassTypeDescriptor.java
+++ b/core/src/main/java/com/spotify/missinglink/datamodel/ClassTypeDescriptor.java
@@ -15,16 +15,15 @@
  */
 package com.spotify.missinglink.datamodel;
 
-import com.google.common.base.Preconditions;
-
 import java.util.InputMismatchException;
+import java.util.Objects;
 
 public class ClassTypeDescriptor implements TypeDescriptor {
 
   private final String className;
 
   ClassTypeDescriptor(String className) {
-    this.className = Preconditions.checkNotNull(className).replace('/', '.');
+    this.className = Objects.requireNonNull(className).replace('/', '.');
     if (className.endsWith(";")) {
       throw new InputMismatchException(
           "Got a signature where a class name was expected: " + className);

--- a/core/src/main/java/com/spotify/missinglink/datamodel/DeclaredClass.java
+++ b/core/src/main/java/com/spotify/missinglink/datamodel/DeclaredClass.java
@@ -15,9 +15,9 @@
  */
 package com.spotify.missinglink.datamodel;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.norberg.automatter.AutoMatter;
+import java.util.Map;
+import java.util.Set;
 
 @AutoMatter
 public interface DeclaredClass {
@@ -26,13 +26,13 @@ public interface DeclaredClass {
   ClassTypeDescriptor className();
 
   // parent are class names: com/foo/bar/Baz
-  ImmutableSet<ClassTypeDescriptor> parents();
+  Set<ClassTypeDescriptor> parents();
   // also includes other classes that are loaded by this class, even though
   // no methods on those classes are explicitly called
-  ImmutableSet<ClassTypeDescriptor> loadedClasses();
+  Set<ClassTypeDescriptor> loadedClasses();
 
-  ImmutableMap<MethodDescriptor, DeclaredMethod> methods();
+  Map<MethodDescriptor, DeclaredMethod> methods();
 
-  ImmutableSet<DeclaredField> fields();
+  Set<DeclaredField> fields();
 
 }

--- a/core/src/main/java/com/spotify/missinglink/datamodel/DeclaredMethod.java
+++ b/core/src/main/java/com/spotify/missinglink/datamodel/DeclaredMethod.java
@@ -15,9 +15,8 @@
  */
 package com.spotify.missinglink.datamodel;
 
-import com.google.common.collect.ImmutableSet;
-
 import io.norberg.automatter.AutoMatter;
+import java.util.Set;
 
 @AutoMatter
 // TODO: rename to something better - ImplementedMethod ? DefinedMethod ?
@@ -30,7 +29,7 @@ public interface DeclaredMethod {
   int lineNumber();
 
   /** Calls that this method makes to other methods */
-  ImmutableSet<CalledMethod> methodCalls();
+  Set<CalledMethod> methodCalls();
 
-  ImmutableSet<AccessedField> fieldAccesses();
+  Set<AccessedField> fieldAccesses();
 }

--- a/core/src/main/java/com/spotify/missinglink/datamodel/MethodDescriptor.java
+++ b/core/src/main/java/com/spotify/missinglink/datamodel/MethodDescriptor.java
@@ -15,11 +15,9 @@
  */
 package com.spotify.missinglink.datamodel;
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
-import java.util.stream.Collectors;
-
 import io.norberg.automatter.AutoMatter;
+import java.util.List;
+import java.util.StringJoiner;
 
 @AutoMatter
 public interface MethodDescriptor {
@@ -28,7 +26,7 @@ public interface MethodDescriptor {
 
   String name();
 
-  ImmutableList<TypeDescriptor> parameterTypes();
+  List<TypeDescriptor> parameterTypes();
 
   // TODO: add modifiers
 
@@ -41,9 +39,12 @@ public interface MethodDescriptor {
   }
 
   default String prettyParameters() {
-    return "(" +
-           Joiner.on(", ").join(parameterTypes().stream()
-                                    .map(TypeDescriptor::toString)
-                                    .collect(Collectors.toList())) + ")";
+    StringJoiner joiner = new StringJoiner(", ", "(", ")");
+
+    parameterTypes().stream()
+        .map(TypeDescriptor::toString)
+        .forEach(joiner::add);
+
+    return joiner.toString();
   }
 }

--- a/core/src/main/java/com/spotify/missinglink/datamodel/MethodDescriptors.java
+++ b/core/src/main/java/com/spotify/missinglink/datamodel/MethodDescriptors.java
@@ -15,17 +15,14 @@
  */
 package com.spotify.missinglink.datamodel;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
-
-import org.objectweb.asm.Type;
+import static java.util.stream.Collectors.toList;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static java.util.stream.Collectors.toList;
+import java.util.Objects;
+import org.objectweb.asm.Type;
 
 public final class MethodDescriptors {
 
@@ -48,7 +45,7 @@ public final class MethodDescriptors {
     return new MethodDescriptorBuilder()
         .returnType(TypeDescriptors.fromRaw(type.getReturnType().getDescriptor()))
         .name(key.name)
-        .parameterTypes(ImmutableList.copyOf(params))
+        .parameterTypes(params)
         .build();
   }
 
@@ -59,8 +56,8 @@ public final class MethodDescriptors {
     private final String desc;
 
     MethodKey(String name, String desc) {
-      this.name = Preconditions.checkNotNull(name);
-      this.desc = Preconditions.checkNotNull(desc);
+      this.name = Objects.requireNonNull(name);
+      this.desc = Objects.requireNonNull(desc);
     }
 
     @Override

--- a/core/src/main/java/com/spotify/missinglink/datamodel/PrimitiveTypeDescriptor.java
+++ b/core/src/main/java/com/spotify/missinglink/datamodel/PrimitiveTypeDescriptor.java
@@ -15,7 +15,9 @@
  */
 package com.spotify.missinglink.datamodel;
 
-import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 public enum PrimitiveTypeDescriptor implements TypeDescriptor {
 
@@ -39,14 +41,14 @@ public enum PrimitiveTypeDescriptor implements TypeDescriptor {
     return Character.toString(raw);
   }
 
-  private static final ImmutableMap<String, PrimitiveTypeDescriptor> mapping = createMapping();
+  private static final Map<String, PrimitiveTypeDescriptor> mapping = createMapping();
 
-  private static ImmutableMap<String, PrimitiveTypeDescriptor> createMapping() {
-    ImmutableMap.Builder<String, PrimitiveTypeDescriptor> bob = ImmutableMap.builder();
+  private static Map<String, PrimitiveTypeDescriptor> createMapping() {
+    final Map<String, PrimitiveTypeDescriptor> map = new HashMap<>();
     for (PrimitiveTypeDescriptor type : PrimitiveTypeDescriptor.values()) {
-      bob.put(Character.toString(type.raw), type);
+      map.put(Character.toString(type.raw), type);
     }
-    return bob.build();
+    return Collections.unmodifiableMap(map);
   }
 
   public static PrimitiveTypeDescriptor fromRaw(String typeDescriptor) {

--- a/core/src/test/java/com/spotify/missinglink/ArtifactLoaderTest.java
+++ b/core/src/test/java/com/spotify/missinglink/ArtifactLoaderTest.java
@@ -15,9 +15,6 @@
  */
 package com.spotify.missinglink;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-
 import com.spotify.missinglink.datamodel.AccessedField;
 import com.spotify.missinglink.datamodel.Artifact;
 import com.spotify.missinglink.datamodel.CalledMethod;
@@ -32,6 +29,7 @@ import com.spotify.missinglink.datamodel.MethodDescriptorBuilder;
 import com.spotify.missinglink.datamodel.TypeDescriptor;
 import com.spotify.missinglink.datamodel.TypeDescriptors;
 
+import java.util.Collections;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
@@ -66,26 +64,23 @@ public class ArtifactLoaderTest {
     methodOneDescriptor = new MethodDescriptorBuilder()
         .returnType(TypeDescriptors.fromRaw("V"))
         .name("methodOne")
-        .parameterTypes(ImmutableList.of(TypeDescriptors.fromRaw("Ljava/lang/String;")))
+        .parameterTypes(Collections.singletonList(TypeDescriptors.fromRaw("Ljava/lang/String;")))
         .build();
 
     internalStaticFieldAccessDescriptor = new MethodDescriptorBuilder()
         .returnType(TypeDescriptors.fromRaw("V"))
         .name("internalStaticFieldAccess")
-        .parameterTypes(ImmutableList.of())
         .build();
 
     internalFieldAccessDescriptor = new MethodDescriptorBuilder()
         .returnType(TypeDescriptors.fromRaw("V"))
         .name("internalFieldAccess")
-        .parameterTypes(ImmutableList.of())
         .build();
 
     printlnDescriptor = new MethodDescriptorBuilder()
         .returnType(TypeDescriptors.fromRaw("V"))
         .name("println")
-        .parameterTypes(ImmutableList.of(TypeDescriptors.fromRaw(
-                "Ljava/lang/String;")))
+        .parameterTypes(Collections.singletonList(TypeDescriptors.fromRaw("Ljava/lang/String;")))
         .build();
   }
 
@@ -167,7 +162,7 @@ public class ArtifactLoaderTest {
   @Test
   public void testLoadParent() throws Exception {
     assertEquals(artifact.classes().get(TypeDescriptors.fromClassName("A")).parents(),
-                 ImmutableSet.of(TypeDescriptors.fromClassName("java/lang/Object")));
+        Collections.singleton(TypeDescriptors.fromClassName("java/lang/Object")));
   }
 
   /**

--- a/core/src/test/java/com/spotify/missinglink/ClassLoadingUtil.java
+++ b/core/src/test/java/com/spotify/missinglink/ClassLoadingUtil.java
@@ -15,7 +15,6 @@
  */
 package com.spotify.missinglink;
 
-import com.google.common.collect.ImmutableList;
 import com.spotify.missinglink.datamodel.Artifact;
 import java.io.File;
 import java.io.FileInputStream;
@@ -31,7 +30,7 @@ import java.util.stream.StreamSupport;
 public class ClassLoadingUtil {
 
   private static final ArtifactLoader artifactLoader = new ArtifactLoader();
-  private static final AtomicReference<ImmutableList<Artifact>> bootstrapArtifacts =
+  private static final AtomicReference<List<Artifact>> bootstrapArtifacts =
       new AtomicReference<>();
 
   public static FileInputStream findClass(Class<?> aClass) throws Exception {
@@ -52,14 +51,14 @@ public class ClassLoadingUtil {
       String bootstrapClasspath = System.getProperty("sun.boot.class.path");
 
       if (bootstrapClasspath != null) {
-        ImmutableList<Artifact> artifacts = ImmutableList.copyOf(constructArtifacts(Arrays.asList(
+        List<Artifact> artifacts = constructArtifacts(Arrays.asList(
             bootstrapClasspath.split(System.getProperty("path.separator"))))
             .stream()
             .filter(c -> !c.name().name().equals("test-classes"))
-            .collect(Collectors.toList()));
+            .collect(Collectors.toList());
         bootstrapArtifacts.set(artifacts);
       } else {
-        ImmutableList<Artifact> artifacts = Java9ModuleLoader
+        List<Artifact> artifacts = Java9ModuleLoader
             .getJava9ModuleArtifacts((s, ex) -> ex.printStackTrace());
         bootstrapArtifacts.set(artifacts);
       }
@@ -67,7 +66,7 @@ public class ClassLoadingUtil {
     return bootstrapArtifacts.get();
   }
 
-  private static ImmutableList<Artifact> constructArtifacts(Iterable<String> entries) {
+  private static List<Artifact> constructArtifacts(Iterable<String> entries) {
     final List<Artifact> list = StreamSupport.stream(entries.spliterator(), false)
         // don't inspect paths that don't exist.
         // some bootclasspath entries, like sunrsasign.jar, are reported even if they
@@ -76,7 +75,7 @@ public class ClassLoadingUtil {
         .filter(ClassLoadingUtil::filterValidClasspathEntries)
         .map(ClassLoadingUtil::filepathToArtifact)
         .collect(Collectors.toList());
-    return ImmutableList.copyOf(list);
+    return list;
   }
 
   private static boolean filterValidClasspathEntries(String element) {

--- a/core/src/test/java/com/spotify/missinglink/FeatureTest.java
+++ b/core/src/test/java/com/spotify/missinglink/FeatureTest.java
@@ -30,9 +30,6 @@ import static com.spotify.missinglink.Simple.newMethod;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.spotify.missinglink.Conflict.ConflictCategory;
 import com.spotify.missinglink.datamodel.AccessedField;
 import com.spotify.missinglink.datamodel.Artifact;
@@ -46,8 +43,10 @@ import com.spotify.missinglink.datamodel.Dependency;
 import com.spotify.missinglink.datamodel.FieldDependencyBuilder;
 import com.spotify.missinglink.datamodel.MethodDependencyBuilder;
 import com.spotify.missinglink.datamodel.TypeDescriptors;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import org.junit.Test;
 
 public class FeatureTest {
@@ -64,7 +63,7 @@ public class FeatureTest {
 
     final CalledMethod methodCall = newCall(fooClass, methodOnlyInD1, false, true);
     final DeclaredMethod mainMethod = newMethod(true, VOID, "main")
-        .methodCalls(ImmutableSet.of(methodCall)).build();
+        .methodCalls(Collections.singleton(methodCall)).build();
 
     final DeclaredClass rootClass = newClass("com/Root")
         .methods(methodMap(mainMethod))
@@ -72,7 +71,7 @@ public class FeatureTest {
 
     final Artifact root = newArtifact("root", rootClass);
 
-    final ImmutableList<Artifact> classpath = ImmutableList.of(root, d2);
+    final List<Artifact> classpath = Arrays.asList(root, d2);
 
     final Conflict expectedConflict = new ConflictBuilder()
         .dependency(dependency(rootClass.className(), mainMethod, methodCall))
@@ -84,7 +83,7 @@ public class FeatureTest {
 
     assertThat(conflictChecker
         .check(root, classpath, classpath))
-        .isEqualTo(ImmutableList.of(expectedConflict));
+        .isEqualTo(Collections.singletonList(expectedConflict));
   }
 
   @org.junit.Test
@@ -100,7 +99,7 @@ public class FeatureTest {
 
     final CalledMethod methodCall = newCall(fooClass, methodOnlyInD1, false, true);
     final DeclaredMethod mainMethod = newMethod(true, VOID, "main", array(STRING))
-        .methodCalls(ImmutableSet.of(methodCall))
+        .methodCalls(Collections.singleton(methodCall))
         .build();
 
     final DeclaredClass rootClass = newClass("com/Root")
@@ -109,7 +108,7 @@ public class FeatureTest {
 
     final Artifact root = newArtifact("root", rootClass);
 
-    final ImmutableList<Artifact> classpath = ImmutableList.of(root, d2);
+    final List<Artifact> classpath = Arrays.asList(root, d2);
 
     final Conflict expectedConflict = new ConflictBuilder()
         .dependency(dependency(rootClass.className(), mainMethod, methodCall))
@@ -121,7 +120,7 @@ public class FeatureTest {
 
     assertThat(conflictChecker
         .check(root, classpath, classpath))
-        .isEqualTo(ImmutableList.of(expectedConflict));
+        .isEqualTo(Collections.singletonList(expectedConflict));
   }
 
   @org.junit.Test
@@ -131,8 +130,7 @@ public class FeatureTest {
     final Artifact d2 = newArtifact("D2", d2Class);
 
     final DeclaredMethod mainMethod = newMethod(true, VOID, "main", array(STRING))
-        .methodCalls(ImmutableSet.of())
-        .fieldAccesses(ImmutableSet.of(
+        .fieldAccesses(Collections.singleton(
             newAccess("I", "foo", "com/d/Foo", 12)
         ))
         .build();
@@ -143,7 +141,7 @@ public class FeatureTest {
 
     final Artifact root = newArtifact("root", rootClass);
 
-    final ImmutableList<Artifact> classpath = ImmutableList.of(root, d2);
+    final List<Artifact> classpath = Arrays.asList(root, d2);
 
     final AccessedField accessed = newAccess(INT, "foo", "com/d/Foo", 12);
 
@@ -157,7 +155,7 @@ public class FeatureTest {
 
     assertThat(conflictChecker
         .check(root, classpath, classpath))
-        .isEqualTo(ImmutableList.of(expectedConflict));
+        .isEqualTo(Collections.singletonList(expectedConflict));
   }
 
   @org.junit.Test
@@ -166,13 +164,12 @@ public class FeatureTest {
     final DeclaredClass superClass =
         newClass("com/super").methods(methodMap(methodOnlyInSuper)).build();
     final DeclaredClass subClass = newClass("com/Sub")
-        .parents(ImmutableSet.of(superClass.className()))
+        .parents(Collections.singleton(superClass.className()))
         .build();
 
     final CalledMethod methodCall = newCall(subClass, methodOnlyInSuper, false, true);
     final DeclaredMethod mainMethod = newMethod(true, VOID, "main", array(STRING))
-        .methodCalls(ImmutableSet.of(methodCall))
-        .fieldAccesses(ImmutableSet.of())
+        .methodCalls(Collections.singleton(methodCall))
         .build();
 
     final DeclaredClass mainClass = newClass("com/Main").methods(methodMap(mainMethod)).build();
@@ -180,8 +177,8 @@ public class FeatureTest {
     final Artifact artifact = newArtifact("art", superClass, subClass, mainClass);
 
     assertThat(conflictChecker.check(artifact,
-        ImmutableList.of(artifact),
-        ImmutableList.of(artifact)
+        Collections.singletonList(artifact),
+        Collections.singletonList(artifact)
     )).isEmpty();
   }
 
@@ -192,12 +189,12 @@ public class FeatureTest {
 
     final DeclaredMethod subMethod = newMethod(false, "Ljava/lang/String;", "foo").build();
     final DeclaredClass subClass = newClass("com/Sub").methods(methodMap(subMethod))
-        .parents(ImmutableSet.of(superClass.className()))
+        .parents(Collections.singleton(superClass.className()))
         .build();
 
     final CalledMethod methodCall = newCall(subClass, superMethod, false, true);
     final DeclaredMethod mainMethod = newMethod(true, VOID, "main", array(STRING))
-        .methodCalls(ImmutableSet.of(methodCall))
+        .methodCalls(Collections.singleton(methodCall))
         .build();
 
     final DeclaredClass mainClass = newClass("com/Main").methods(methodMap(mainMethod)).build();
@@ -206,8 +203,8 @@ public class FeatureTest {
 
     assertThat(conflictChecker
         .check(artifact,
-            ImmutableList.of(artifact),
-            ImmutableList.of(artifact)
+            Collections.singletonList(artifact),
+            Collections.singletonList(artifact)
         )).isEmpty();
   }
 
@@ -219,8 +216,7 @@ public class FeatureTest {
 
     final CalledMethod methodCall = newCall(superClass, methodOnlyInSuper, true, false);
     final DeclaredMethod mainMethod = newMethod(true, VOID, "main", array(STRING))
-        .methodCalls(ImmutableSet.of(methodCall))
-        .fieldAccesses(ImmutableSet.of())
+        .methodCalls(Collections.singleton(methodCall))
         .build();
 
     final DeclaredClass mainClass = newClass("com/Main").methods(methodMap(mainMethod)).build();
@@ -228,8 +224,8 @@ public class FeatureTest {
     final Artifact artifact = newArtifact("art", superClass, mainClass);
 
     assertThat(conflictChecker.check(artifact,
-        ImmutableList.of(artifact),
-        ImmutableList.of(artifact)
+        Collections.singletonList(artifact),
+        Collections.singletonList(artifact)
     )).isEmpty();
   }
 
@@ -241,8 +237,7 @@ public class FeatureTest {
 
     final CalledMethod methodCall = newCall(superClass, methodOnlyInSuper, true, false);
     final DeclaredMethod mainMethod = newMethod(true, VOID, "main", array(STRING))
-        .methodCalls(ImmutableSet.of(methodCall))
-        .fieldAccesses(ImmutableSet.of())
+        .methodCalls(Collections.singleton(methodCall))
         .build();
 
     final DeclaredClass mainClass = newClass("com/Main").methods(methodMap(mainMethod)).build();
@@ -257,10 +252,10 @@ public class FeatureTest {
         .existsIn(artifact.name())
         .build();
 
-    assertEquals(Arrays.asList(expectedConflict),
+    assertEquals(Collections.singletonList(expectedConflict),
         conflictChecker.check(artifact,
-            ImmutableList.of(artifact),
-            ImmutableList.of(artifact)
+            Collections.singletonList(artifact),
+            Collections.singletonList(artifact)
         ));
   }
 
@@ -272,12 +267,11 @@ public class FeatureTest {
 
     final CalledMethod methodCall = newCall(superClass, methodOnlyInSuper, false, true);
     final DeclaredMethod mainMethod = newMethod(true, VOID, "main", array(STRING))
-        .methodCalls(ImmutableSet.of(methodCall))
-        .fieldAccesses(ImmutableSet.of())
+        .methodCalls(Collections.singleton(methodCall))
         .build();
 
     final DeclaredClass mainClass = newClass("com/Main")
-        .parents(ImmutableSet.of(superClass.className()))
+        .parents(Collections.singleton(superClass.className()))
         .methods(methodMap(mainMethod)).build();
 
     final Artifact artifact = newArtifact("art", superClass, mainClass);
@@ -290,10 +284,10 @@ public class FeatureTest {
         .existsIn(artifact.name())
         .build();
 
-    assertEquals(Arrays.asList(expectedConflict),
+    assertEquals(Collections.singletonList(expectedConflict),
         conflictChecker.check(artifact,
-            ImmutableList.of(artifact),
-            ImmutableList.of(artifact)
+            Collections.singletonList(artifact),
+            Collections.singletonList(artifact)
         ));
   }
 
@@ -306,20 +300,19 @@ public class FeatureTest {
     ClassTypeDescriptor mainClassName = TypeDescriptors.fromClassName("com/Main");
     final CalledMethod methodCall = newCall(mainClassName, methodOnlyInSuper, true);
     final DeclaredMethod mainMethod = newMethod(true, VOID, "main", array(STRING))
-        .methodCalls(ImmutableSet.of(methodCall))
-        .fieldAccesses(ImmutableSet.of())
+        .methodCalls(Collections.singleton(methodCall))
         .build();
 
     final DeclaredClass mainClass = newClass("com/Main")
-        .parents(ImmutableSet.of(superClass.className()))
+        .parents(Collections.singleton(superClass.className()))
         .methods(methodMap(mainMethod)).build();
 
     final Artifact artifact = newArtifact("art", superClass, mainClass);
 
     assertEquals(Collections.emptyList(),
         conflictChecker.check(artifact,
-            ImmutableList.of(artifact),
-            ImmutableList.of(artifact)
+            Collections.singletonList(artifact),
+            Collections.singletonList(artifact)
         ));
   }
 
@@ -349,13 +342,11 @@ public class FeatureTest {
 
     final Artifact artifact = newArtifact("art", superDuperClass, superClass, mainClass);
 
-    ImmutableList<Artifact> allArtifacts = ImmutableList.<Artifact>builder()
-        .addAll(ClassLoadingUtil.bootstrapArtifacts())
-        .add(artifact)
-        .build();
+    List<Artifact> allArtifacts = new ArrayList<>(ClassLoadingUtil.bootstrapArtifacts());
+    allArtifacts.add(artifact);
 
     assertThat(conflictChecker.check(artifact,
-        ImmutableList.of(artifact),
+        Collections.singletonList(artifact),
         allArtifacts)).isEmpty();
   }
 
@@ -374,10 +365,8 @@ public class FeatureTest {
 
     final Artifact artifact = newArtifact("art", mainClass);
 
-    ImmutableList<Artifact> allArtifacts = ImmutableList.<Artifact>builder()
-        .addAll(ClassLoadingUtil.bootstrapArtifacts())
-        .add(artifact)
-        .build();
+    List<Artifact> allArtifacts = new ArrayList<>(ClassLoadingUtil.bootstrapArtifacts());
+    allArtifacts.add(artifact);
 
     DeclaredMethod parentInit = parent.methods().values().stream()
         .filter(declaredMethod -> declaredMethod.descriptor().name().equals("<init>"))
@@ -404,7 +393,7 @@ public class FeatureTest {
         .build();
 
     assertThat(conflictChecker.check(artifact,
-        ImmutableList.of(artifact),
+        Collections.singletonList(artifact),
         allArtifacts))
 
         .containsExactly(expectedConflict);
@@ -434,13 +423,11 @@ public class FeatureTest {
 
     final Artifact artifact = newArtifact("art", catcher);
 
-    ImmutableList<Artifact> allArtifacts = ImmutableList.<Artifact>builder()
-        .addAll(ClassLoadingUtil.bootstrapArtifacts())
-        .add(artifact)
-        .build();
+    List<Artifact> allArtifacts = new ArrayList<>(ClassLoadingUtil.bootstrapArtifacts());
+    allArtifacts.add(artifact);
 
     assertThat(conflictChecker.check(artifact,
-        ImmutableList.of(artifact),
+        Collections.singletonList(artifact),
         allArtifacts))
         .isEmpty();
   }
@@ -467,19 +454,17 @@ public class FeatureTest {
 
     DeclaredClass missingMethod = DeclaredClassBuilder
         .from(load(findClass(MissingMethodClass.class)))
-        .methods(ImmutableMap.of()).build();
+        .build();
 
     DeclaredClass catcher = load(findClass(CatchesMissingMethod.class));
 
     final Artifact artifact = newArtifact("art", catcher, missingMethod);
 
-    ImmutableList<Artifact> allArtifacts = ImmutableList.<Artifact>builder()
-        .addAll(ClassLoadingUtil.bootstrapArtifacts())
-        .add(artifact)
-        .build();
+    List<Artifact> allArtifacts = new ArrayList<>(ClassLoadingUtil.bootstrapArtifacts());
+    allArtifacts.add(artifact);
 
     assertThat(conflictChecker.check(artifact,
-        ImmutableList.of(artifact),
+        Collections.singletonList(artifact),
         allArtifacts))
         .isEmpty();
   }

--- a/core/src/test/java/com/spotify/missinglink/ReachableTest.java
+++ b/core/src/test/java/com/spotify/missinglink/ReachableTest.java
@@ -15,20 +15,6 @@
  */
 package com.spotify.missinglink;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-
-import com.spotify.missinglink.datamodel.ClassTypeDescriptor;
-import com.spotify.missinglink.datamodel.DeclaredClass;
-import com.spotify.missinglink.datamodel.DeclaredMethod;
-import com.spotify.missinglink.datamodel.MethodDescriptor;
-import com.spotify.missinglink.datamodel.TypeDescriptor;
-import com.spotify.missinglink.datamodel.TypeDescriptors;
-
-import org.junit.Test;
-
-import java.util.Map;
-import java.util.Set;
 
 import static com.spotify.missinglink.Simple.INT;
 import static com.spotify.missinglink.Simple.VOID;
@@ -40,16 +26,29 @@ import static com.spotify.missinglink.Simple.newField;
 import static com.spotify.missinglink.Simple.newMethod;
 import static org.junit.Assert.assertEquals;
 
+import com.spotify.missinglink.datamodel.ClassTypeDescriptor;
+import com.spotify.missinglink.datamodel.DeclaredClass;
+import com.spotify.missinglink.datamodel.DeclaredMethod;
+import com.spotify.missinglink.datamodel.MethodDescriptor;
+import com.spotify.missinglink.datamodel.TypeDescriptor;
+import com.spotify.missinglink.datamodel.TypeDescriptors;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+
 public class ReachableTest {
 
   @Test
   public void testUnreachable() {
     DeclaredClass root = newClass("my/Root").build();
-    ImmutableSet< DeclaredClass > myClasses = ImmutableSet.of(root);
+    Set<DeclaredClass> myClasses = Collections.singleton(root);
     Map<ClassTypeDescriptor, DeclaredClass> world =
         classMap(root, newClass("other/Unknown").build());
     Set<TypeDescriptor> reachable = ConflictChecker.reachableFrom(myClasses, world);
-    assertEquals(ImmutableSet.of(root.className()), reachable);
+    assertEquals(Collections.singleton(root.className()), reachable);
   }
 
   @Test
@@ -62,12 +61,15 @@ public class ReachableTest {
         .methods(methodMap(
             newMethod(false, VOID, "foo")
                 .methodCalls(
-                    ImmutableSet.of(newCall(remote, remoteMethod, false, true))).build()))
+                    Collections.singleton(newCall(remote, remoteMethod, false, true))).build()))
         .build();
-    ImmutableSet<DeclaredClass> myClasses = ImmutableSet.of(root);
-    ImmutableMap<ClassTypeDescriptor, DeclaredClass> world = classMap(root, remote);
-    ImmutableSet<TypeDescriptor> reachable = ConflictChecker.reachableFrom(myClasses, world);
-    assertEquals(ImmutableSet.of(root.className(), remote.className()), reachable);
+    Set<DeclaredClass> myClasses = Collections.singleton(root);
+    Map<ClassTypeDescriptor, DeclaredClass> world = classMap(root, remote);
+    Set<TypeDescriptor> reachable = ConflictChecker.reachableFrom(myClasses, world);
+    Set<ClassTypeDescriptor> expected = new HashSet<>(Arrays.asList(
+        root.className(), remote.className()
+    ));
+    assertEquals(expected, reachable);
   }
 
   @Test
@@ -75,12 +77,15 @@ public class ReachableTest {
     DeclaredClass remote = newClass("other/Unknown")
         .build();
     DeclaredClass root = newClass("my/Root")
-        .parents(ImmutableSet.of(TypeDescriptors.fromClassName("other/Unknown")))
+        .parents(Collections.singleton(TypeDescriptors.fromClassName("other/Unknown")))
         .build();
-    ImmutableSet<DeclaredClass> myClasses = ImmutableSet.of(root);
-    ImmutableMap<ClassTypeDescriptor, DeclaredClass> world = classMap(root, remote);
-    ImmutableSet<TypeDescriptor> reachable = ConflictChecker.reachableFrom(myClasses, world);
-    assertEquals(ImmutableSet.of(root.className(), remote.className()), reachable);
+    Set<DeclaredClass> myClasses = Collections.singleton(root);
+    Map<ClassTypeDescriptor, DeclaredClass> world = classMap(root, remote);
+    Set<TypeDescriptor> reachable = ConflictChecker.reachableFrom(myClasses, world);
+    Set<ClassTypeDescriptor> expected = new HashSet<>(Arrays.asList(
+        root.className(), remote.className()
+    ));
+    assertEquals(expected, reachable);
   }
 
   @Test
@@ -88,31 +93,37 @@ public class ReachableTest {
     DeclaredClass remote = newClass("other/Unknown")
         .build();
     DeclaredClass root = newClass("my/Root")
-        .loadedClasses(ImmutableSet.of(TypeDescriptors.fromClassName("other/Unknown")))
+        .loadedClasses(Collections.singleton(TypeDescriptors.fromClassName("other/Unknown")))
         .build();
-    ImmutableSet<DeclaredClass> myClasses = ImmutableSet.of(root);
-    ImmutableMap<ClassTypeDescriptor, DeclaredClass> world = classMap(root, remote);
-    ImmutableSet<TypeDescriptor> reachable = ConflictChecker.reachableFrom(myClasses, world);
-    assertEquals(ImmutableSet.of(root.className(), remote.className()), reachable);
+    Set<DeclaredClass> myClasses = Collections.singleton(root);
+    Map<ClassTypeDescriptor, DeclaredClass> world = classMap(root, remote);
+    Set<TypeDescriptor> reachable = ConflictChecker.reachableFrom(myClasses, world);
+    Set<ClassTypeDescriptor> expected = new HashSet<>(Arrays.asList(
+        root.className(), remote.className()
+    ));
+    assertEquals(expected, reachable);
   }
 
   @Test
   public void testReachableViaField() {
     DeclaredClass remote = newClass("other/Unknown")
-        .fields(ImmutableSet.of(newField(INT, "remoteField")))
+        .fields(Collections.singleton(newField(INT, "remoteField")))
         .build();
-    ImmutableMap<MethodDescriptor, DeclaredMethod> methods = methodMap(
+    Map<MethodDescriptor, DeclaredMethod> methods = methodMap(
         newMethod(false, VOID, "foo")
             .fieldAccesses(
-                ImmutableSet.of(Simple.newAccess(INT, "remoteField", "other/Unknown", 12)))
+                Collections.singleton(Simple.newAccess(INT, "remoteField", "other/Unknown", 12)))
             .build());
     DeclaredClass root = newClass("my/Root")
         .methods(methods)
         .build();
-    ImmutableSet< DeclaredClass > myClasses = ImmutableSet.of(root);
-    ImmutableMap<ClassTypeDescriptor, DeclaredClass> world = classMap(root, remote);
-    ImmutableSet<TypeDescriptor> reachable = ConflictChecker.reachableFrom(myClasses, world);
-    assertEquals(ImmutableSet.of(root.className(), remote.className()), reachable);
+    Set<DeclaredClass> myClasses = Collections.singleton(root);
+    Map<ClassTypeDescriptor, DeclaredClass> world = classMap(root, remote);
+    Set<TypeDescriptor> reachable = ConflictChecker.reachableFrom(myClasses, world);
+    Set<ClassTypeDescriptor> expected = new HashSet<>(Arrays.asList(
+        root.className(), remote.className()
+    ));
+    assertEquals(expected, reachable);
   }
 
 }

--- a/core/src/test/java/com/spotify/missinglink/Simple.java
+++ b/core/src/test/java/com/spotify/missinglink/Simple.java
@@ -15,10 +15,6 @@
  */
 package com.spotify.missinglink;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-
 import com.spotify.missinglink.datamodel.AccessedField;
 import com.spotify.missinglink.datamodel.AccessedFieldBuilder;
 import com.spotify.missinglink.datamodel.Artifact;
@@ -37,8 +33,10 @@ import com.spotify.missinglink.datamodel.MethodDescriptor;
 import com.spotify.missinglink.datamodel.MethodDescriptorBuilder;
 import com.spotify.missinglink.datamodel.TypeDescriptor;
 import com.spotify.missinglink.datamodel.TypeDescriptors;
-
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -63,28 +61,23 @@ public class Simple {
    */
   public static DeclaredClassBuilder newClass(String className) {
     return new DeclaredClassBuilder()
-        .className(TypeDescriptors.fromClassName(className))
-        .parents(ImmutableSet.of())
-        .loadedClasses(ImmutableSet.of())
-        .methods(ImmutableMap.of())
-        .fields(ImmutableSet.<DeclaredField>of());
+        .className(TypeDescriptors.fromClassName(className));
   }
 
 
   public static DeclaredMethodBuilder newMethod(boolean isStatic, String returnDesc, String name,
                                                 String... parameterDesc) {
-    List<TypeDescriptor> param = ImmutableList.copyOf(parameterDesc).stream()
+    List<TypeDescriptor> param = Arrays.stream(parameterDesc)
         .map(TypeDescriptors::fromRaw)
         .collect(Collectors.toList());
 
     return new DeclaredMethodBuilder()
         .isStatic(isStatic)
-        .fieldAccesses(ImmutableSet.<AccessedField>of())
-        .methodCalls(ImmutableSet.<CalledMethod>of())
         .descriptor(new MethodDescriptorBuilder()
             .name(name)
-        .parameterTypes(ImmutableList.copyOf(param))
-        .returnType(TypeDescriptors.fromRaw(returnDesc)).build());
+            .parameterTypes(param)
+            .returnType(TypeDescriptors.fromRaw(returnDesc)).build()
+        );
   }
 
   public static CalledMethod newCall(
@@ -102,22 +95,20 @@ public class Simple {
         .build();
   }
 
-  public static ImmutableMap<ClassTypeDescriptor, DeclaredClass> classMap(
-      DeclaredClass... classes) {
-    ImmutableMap.Builder<ClassTypeDescriptor, DeclaredClass> builder = ImmutableMap.builder();
+  public static Map<ClassTypeDescriptor, DeclaredClass> classMap(DeclaredClass... classes) {
+    Map<ClassTypeDescriptor, DeclaredClass> map = new HashMap<>();
     for (DeclaredClass clazz : classes) {
-      builder.put(clazz.className(), clazz);
+      map.put(clazz.className(), clazz);
     }
-    return builder.build();
+    return map;
   }
 
-  public static ImmutableMap<MethodDescriptor, DeclaredMethod> methodMap(
-      DeclaredMethod... methods) {
-    ImmutableMap.Builder<MethodDescriptor, DeclaredMethod> builder = ImmutableMap.builder();
+  public static Map<MethodDescriptor, DeclaredMethod> methodMap(DeclaredMethod... methods) {
+    Map<MethodDescriptor, DeclaredMethod> map = new HashMap<>();
     for (DeclaredMethod method: methods) {
-      builder.put(method.descriptor(), method);
+      map.put(method.descriptor(), method);
     }
-    return builder.build();
+    return map;
   }
 
   public static DeclaredField newField(String desc, String name) {
@@ -137,14 +128,14 @@ public class Simple {
   }
 
   public static Artifact newArtifact(String name, DeclaredClass... classes) {
-    final ImmutableMap.Builder<ClassTypeDescriptor, DeclaredClass> builder = ImmutableMap.builder();
+    final Map<ClassTypeDescriptor, DeclaredClass> map = new HashMap<>();
     for (DeclaredClass clazz : classes) {
-      builder.put(clazz.className(), clazz);
+      map.put(clazz.className(), clazz);
     }
 
     return new ArtifactBuilder()
         .name(new ArtifactName(name))
-        .classes(builder.build())
+        .classes(map)
         .build();
   }
 

--- a/core/src/test/java/com/spotify/missinglink/TypeDescriptorTest.java
+++ b/core/src/test/java/com/spotify/missinglink/TypeDescriptorTest.java
@@ -15,12 +15,12 @@
  */
 package com.spotify.missinglink;
 
-import com.google.common.collect.ImmutableMap;
 import com.spotify.missinglink.datamodel.ArrayTypeDescriptor;
 import com.spotify.missinglink.datamodel.ClassTypeDescriptor;
 import com.spotify.missinglink.datamodel.PrimitiveTypeDescriptor;
 import com.spotify.missinglink.datamodel.TypeDescriptor;
 import com.spotify.missinglink.datamodel.TypeDescriptors;
+import java.util.HashMap;
 import org.junit.Test;
 
 import java.util.InputMismatchException;
@@ -55,23 +55,23 @@ public class TypeDescriptorTest {
 
   @Test
   public void testDescriptions() {
-    Map<String, String> desc = ImmutableMap.<String, String>builder()
-        .put("B", "byte")
-        .put("S", "short")
-        .put("I", "int")
-        .put("J", "long")
-        .put("F", "float")
-        .put("D", "double")
-        .put("Z", "boolean")
-        .put("C", "char")
-        .put("[D", "double[]")
-        .put("[[D", "double[][]")
-        .put("[[[D", "double[][][]")
-        .put("LFoo;", "Foo")
-        .put("[LFoo;", "Foo[]")
-        .put("[[LFoo;", "Foo[][]")
-        .put("Lfoo/bar/Baz;", "foo.bar.Baz")
-        .build();
+    Map<String, String> desc = new HashMap<>();
+    desc.put("B", "byte");
+    desc.put("S", "short");
+    desc.put("I", "int");
+    desc.put("J", "long");
+    desc.put("F", "float");
+    desc.put("D", "double");
+    desc.put("Z", "boolean");
+    desc.put("C", "char");
+    desc.put("[D", "double[]");
+    desc.put("[[D", "double[][]");
+    desc.put("[[[D", "double[][][]");
+    desc.put("LFoo;", "Foo");
+    desc.put("[LFoo;", "Foo[]");
+    desc.put("[[LFoo;", "Foo[][]");
+    desc.put("Lfoo/bar/Baz;", "foo.bar.Baz");
+
     for (Map.Entry<String, String> entry : desc.entrySet()) {
       assertEquals(entry.getValue(), TypeDescriptors.fromRaw(entry.getKey()).toString());
     }
@@ -80,20 +80,20 @@ public class TypeDescriptorTest {
 
   @Test
   public void testTypes() {
-    Map<String, Class> desc = ImmutableMap.<String, Class>builder()
-        .put("B", PrimitiveTypeDescriptor.class)
-        .put("S", PrimitiveTypeDescriptor.class)
-        .put("I", PrimitiveTypeDescriptor.class)
-        .put("J", PrimitiveTypeDescriptor.class)
-        .put("F", PrimitiveTypeDescriptor.class)
-        .put("D", PrimitiveTypeDescriptor.class)
-        .put("Z", PrimitiveTypeDescriptor.class)
-        .put("C", PrimitiveTypeDescriptor.class)
-        .put("[D", ArrayTypeDescriptor.class)
-        .put("LFoo;", ClassTypeDescriptor.class)
-        .put("[LFoo;", ArrayTypeDescriptor.class)
-        .put("Lfoo/bar/Baz;", ClassTypeDescriptor.class)
-        .build();
+    Map<String, Class> desc = new HashMap<>();
+    desc.put("B", PrimitiveTypeDescriptor.class);
+    desc.put("S", PrimitiveTypeDescriptor.class);
+    desc.put("I", PrimitiveTypeDescriptor.class);
+    desc.put("J", PrimitiveTypeDescriptor.class);
+    desc.put("F", PrimitiveTypeDescriptor.class);
+    desc.put("D", PrimitiveTypeDescriptor.class);
+    desc.put("Z", PrimitiveTypeDescriptor.class);
+    desc.put("C", PrimitiveTypeDescriptor.class);
+    desc.put("[D", ArrayTypeDescriptor.class);
+    desc.put("LFoo;", ClassTypeDescriptor.class);
+    desc.put("[LFoo;", ArrayTypeDescriptor.class);
+    desc.put("Lfoo/bar/Baz;", ClassTypeDescriptor.class);
+
     for (Map.Entry<String, Class> entry : desc.entrySet()) {
       assertEquals(entry.getValue(), TypeDescriptors.fromRaw(entry.getKey()).getClass());
     }

--- a/core/src/test/java/com/spotify/missinglink/datamodel/MethodDescriptorsTest.java
+++ b/core/src/test/java/com/spotify/missinglink/datamodel/MethodDescriptorsTest.java
@@ -15,8 +15,6 @@
  */
 package com.spotify.missinglink.datamodel;
 
-import com.google.common.collect.ImmutableList;
-
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -28,10 +26,11 @@ public class MethodDescriptorsTest {
     MethodDescriptor desc1 = MethodDescriptors.fromDesc("([I[[Lfoo/Bar;Z)V", "baz");
     MethodDescriptor desc2 = new MethodDescriptorBuilder()
         .returnType(TypeDescriptors.fromRaw("V"))
-        .parameterTypes(ImmutableList.of(
+        .parameterTypes(
             TypeDescriptors.fromRaw("[I"),
             TypeDescriptors.fromRaw("[[Lfoo/Bar;"),
-            TypeDescriptors.fromRaw("Z")))
+            TypeDescriptors.fromRaw("Z")
+        )
         .name("baz")
         .build();
     assertEquals("Method descriptors should be identical", desc1, desc2);

--- a/core/src/test/java/com/spotify/missinglink/datamodel/MethodDescriptorsTest.java
+++ b/core/src/test/java/com/spotify/missinglink/datamodel/MethodDescriptorsTest.java
@@ -36,4 +36,10 @@ public class MethodDescriptorsTest {
         .build();
     assertEquals("Method descriptors should be identical", desc1, desc2);
   }
+
+  @Test
+  public void testPrettyParameters() {
+    MethodDescriptor desc = MethodDescriptors.fromDesc("([I[[Lfoo/Bar;Z)V", "baz");
+    assertEquals("(int[], foo.Bar[][], boolean)", desc.prettyParameters());
+  }
 }

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.spotify</groupId>
     <artifactId>missinglink-parent</artifactId>
-    <version>0.1.6-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>missinglink-maven-plugin</artifactId>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -21,6 +21,11 @@
       <artifactId>missinglink-core</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>18.0</version>
+    </dependency>
 
     <!-- maven-plugin-annotations seems to be version differently than Maven API stuff  -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.spotify</groupId>
   <artifactId>missinglink-parent</artifactId>
-  <version>0.1.6-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>missinglink</name>


### PR DESCRIPTION
In the interest of having as few dependencies as possible in the core 
module, this commit removes Guava from it.

Guava was only really used in three ways in the core module:

1. Immutable collection types 2. Preconditions checks 3. Joiner for
concatenating strings

I replaced 1 with a mix of `Collection.singleton()`, `singletonList()` 
etc., along with vanilla ArrayList / HashMap usage. The classes generated
by AutoMatter for POJOs will make copies of any collections passed in, so I
skipped a lot of the usage of Guava's Immutable types for making copies of
collections before passing them into the generated POJOs.

Use of the Preconditions static methods to throw NullPointerExceptions or
IllegalArgumentExceptions I replaced with
`java.util.Objects.checkNotNull()` or vanilla if-else checks.

The plugin module still uses Guava; removing it from that module was out of
scope for this change (anyone using Missinglink in other build tools will
just depend on the core module).

Closes #60.