### PR TITLE
move <prerequisites> to plugin project

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -15,6 +15,10 @@
     <maven.api.version>3.3.3</maven.api.version>
   </properties>
 
+  <prerequisites>
+    <maven>3.0</maven>
+  </prerequisites>
+
   <dependencies>
     <dependency>
       <groupId>com.spotify</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -95,10 +95,6 @@
     </repository>
   </distributionManagement>
 
-  <prerequisites>
-    <maven>3.0</maven>
-  </prerequisites>
-
   <build>
     <pluginManagement>
       <plugins>
@@ -120,6 +116,26 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M3</version>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.0</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>


### PR DESCRIPTION
resolves this warning

```
[INFO] Scanning for projects...
[WARNING] The project com.spotify:missinglink-parent:pom:0.2.3-SNAPSHOT uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html
```
