### PR TITLE
bump maven.api.version from 3.3.3 to 3.8.1

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -19,6 +19,22 @@
     <maven>3.0</maven>
   </prerequisites>
 
+  <dependencyManagement>
+    <dependencies>
+      <!-- some maven-* artifacts do not agree on which versions of plexus dependencies to use -->
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>3.3.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-component-annotations</artifactId>
+        <version>2.1.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>com.spotify</groupId>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -32,6 +32,11 @@
         <artifactId>plexus-component-annotations</artifactId>
         <version>2.1.0</version>
       </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>1.7.30</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>23.0</version>
+      <version>25.1-jre</version>
     </dependency>
 
     <!-- maven-plugin-annotations seems to be version differently than Maven API stuff  -->

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -106,12 +106,6 @@
       <version>3.18.1</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-      <version>1.2.3</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -12,7 +12,7 @@
   <packaging>maven-plugin</packaging>
 
   <properties>
-    <maven.api.version>3.3.3</maven.api.version>
+    <maven.api.version>3.8.1</maven.api.version>
   </properties>
 
   <prerequisites>

--- a/maven-plugin/src/main/java/com/spotify/missinglink/maven/CheckMojo.java
+++ b/maven-plugin/src/main/java/com/spotify/missinglink/maven/CheckMojo.java
@@ -38,6 +38,7 @@ package com.spotify.missinglink.maven;
 import com.google.common.base.Joiner;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Throwables;
+import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
@@ -529,12 +530,12 @@ public class CheckMojo extends AbstractMojo {
     return lineNumber != 0 ? ":" + lineNumber : "";
   }
 
+  @SuppressWarnings("UnstableApiUsage")
   private Artifact toArtifact(String outputDirectory) {
     return new ArtifactBuilder()
         .name(new ArtifactName("project"))
         .classes(
-            Files.fileTreeTraverser()
-                .breadthFirstTraversal(new File(outputDirectory))
+            FluentIterable.from(Files.fileTraverser().breadthFirst(new File(outputDirectory)))
                 .filter(f -> f.getName().endsWith(".class"))
                 .transform(this::loadClass)
                 .uniqueIndex(DeclaredClass::className))

--- a/maven-plugin/src/test/java/com/spotify/missinglink/maven/CheckMojoTest.java
+++ b/maven-plugin/src/test/java/com/spotify/missinglink/maven/CheckMojoTest.java
@@ -80,8 +80,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A note on the maven plugin testing harness:
@@ -100,8 +98,6 @@ import org.slf4j.LoggerFactory;
  * Mojo are set based on the POM XML file.
  */
 public class CheckMojoTest {
-
-  private static final Logger log = LoggerFactory.getLogger(CheckMojoTest.class);
 
   @Rule public MojoRule rule = new MojoRule();
 
@@ -139,7 +135,6 @@ public class CheckMojoTest {
 
   private CheckMojo getMojo(String dirName) throws Exception {
     final File basedir = resources.getBasedir(dirName);
-    log.debug("Constructing Mojo against test basedir {}", basedir);
     final CheckMojo mojo = (CheckMojo) rule.lookupConfiguredMojo(basedir, "check");
     mojo.artifactLoader = artifactLoader;
     mojo.conflictChecker = conflictChecker;

--- a/pom.xml
+++ b/pom.xml
@@ -136,19 +136,19 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>3.0.0-M3</version>
+        <configuration>
+          <rules>
+            <requireMavenVersion>
+              <version>3.0</version>
+            </requireMavenVersion>
+          </rules>
+        </configuration>
         <executions>
           <execution>
             <id>enforce-maven</id>
             <goals>
               <goal>enforce</goal>
             </goals>
-            <configuration>
-              <rules>
-                <requireMavenVersion>
-                  <version>3.0</version>
-                </requireMavenVersion>
-              </rules>
-            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
fixes the conflicts from the dependabot PR in #144