### PR TITLE
Handle Java -ea versions

### DIFF
--- a/core/src/main/java/com/spotify/missinglink/ArtifactLoader.java
+++ b/core/src/main/java/com/spotify/missinglink/ArtifactLoader.java
@@ -114,7 +114,8 @@ public class ArtifactLoader {
 
     // We have to figure out what JVM version we're running on.
     Integer currentJavaVersion;
-    String[] javaVersionElements = System.getProperty("java.version").replaceAll("\\-ea", "").split("\\.");
+    String[] javaVersionElements =
+        System.getProperty("java.version").replaceAll("\\-ea", "").split("\\.");
     if (javaVersionElements[0].equals("1")) {
       currentJavaVersion = Integer.parseInt(javaVersionElements[1]);
     } else {

--- a/core/src/main/java/com/spotify/missinglink/ArtifactLoader.java
+++ b/core/src/main/java/com/spotify/missinglink/ArtifactLoader.java
@@ -114,7 +114,7 @@ public class ArtifactLoader {
 
     // We have to figure out what JVM version we're running on.
     Integer currentJavaVersion;
-    String[] javaVersionElements = System.getProperty("java.version").split("\\.");
+    String[] javaVersionElements = System.getProperty("java.version").replaceAll("\\-ea", "").split("\\.");
     if (javaVersionElements[0].equals("1")) {
       currentJavaVersion = Integer.parseInt(javaVersionElements[1]);
     } else {


### PR DESCRIPTION
Can't decide if we should go for  removing "-ea" or "-.*" ?