### PR TITLE
add java.lang.invoke.VarHandle to ClassLoader.BLACKLIST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 0.2.4
+
+Added `java.lang.invoke.VarHandle` to the list of classes with
+`@HotSpotIntrinsicCandidate` annotated methods which are excluded from analysis.
+Calls to `VarHandle` methods will no longer result in missinglink generating
+false warnings about methods like `getAndSet` not existing.
+
 ### 0.2.3
 
 Upgraded a number of dependencies:
@@ -47,4 +54,3 @@ Internal changes:
 
 ### 0.1.0 (initial release)
 - core project and maven plugin
-

--- a/core/src/main/java/com/spotify/missinglink/ClassLoader.java
+++ b/core/src/main/java/com/spotify/missinglink/ClassLoader.java
@@ -80,7 +80,7 @@ public final class ClassLoader {
   // and thus define native methods that don't actually exist in the class file
   // This could be removed if we stop loading the full JDK
   private static final Set<String> BLACKLIST =
-      new HashSet<>(Arrays.asList("java/lang/invoke/MethodHandle"));
+      new HashSet<>(Arrays.asList("java/lang/invoke/MethodHandle", "java/lang/invoke/VarHandle"));
 
   private ClassLoader() {
     // prevent instantiation


### PR DESCRIPTION
since all of its methods are annotated with
`@HotSpotIntrinsicCandidate`, which means the methods do not actually
appear in the .class file.

I have not added a unit test here since the project still builds with
`source=1.8, target=1.8` in the compiler configuration (and also builds
in CI on Github with Java 8 as one of the java versions to build with).
The VarHandle class was added in JDK9 and does not appear in 8, so to
add a test of class that references VarHandle I'd have to either resort
to some reflection trickery or drop support in the project for building
with `target=8`, which I don't want to do at this time.

I also considered adding logic to exclude all calls to methods annotated
with `@HotSpotIntrinsicCandidate` from missinglink's analysis/warnings,
but this would adding information about a method's annotations to
missinglink's data model (e..g in DeclaredMethod) which does not exist
today.