### PR TITLE
fix method reference of set of incorrect type

### DIFF
--- a/maven-plugin/src/main/java/com/spotify/missinglink/maven/CheckMojo.java
+++ b/maven-plugin/src/main/java/com/spotify/missinglink/maven/CheckMojo.java
@@ -277,7 +277,7 @@ public class CheckMojo extends AbstractMojo {
       conflicts =
           filterConflictsBy(
               conflicts,
-              categoriesToInclude::contains,
+              c -> categoriesToInclude.contains(c.category()),
               num ->
                   num
                       + " conflicts removed based on includeCategories="


### PR DESCRIPTION
`filterConflictsBy` expects a predicate that operates on a Conflict, but the code passes a method reference to `categoriesToInclude::contains`, which is a set of type `ConflictCategory`. Instead, pass a lambda to check if the conflict's category is in the set.

Discovered while porting the Maven implemenation to run with Bazel